### PR TITLE
Add enable_restart docs and move tests to new class

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -64,3 +64,21 @@ must be installed and authorized to download from the specified bucket.
 The ``namelist`` item is special in that it is explicitly stored in the ``config`` dictionary. For the
 fv3gfs model, individual namelists are specified for various components of the model. As an example, the
 vertical resolution can be accessed via ``config['namelist']['fv_core_nml']['npz']``.
+
+Restart runs
+------------
+
+The required namelist settings for a restart run (as opposed to a run initialized from an observational
+analysis) can be applied to a configuration dictionary as follows::
+
+    config = enable_restart(config)
+
+A set of restart files is provided in the cached data files. Thus, an example run directory with model
+restart initial conditions can be created with::
+
+    from fv3config import get_default_config, write_run_directory, enable_restart
+
+    config = get_default_config()
+    config['initial_conditions'] = 'restart_example'
+    config = enable_restart(config)
+    write_run_directory(config, './rundir')

--- a/tests/test_namelist.py
+++ b/tests/test_namelist.py
@@ -175,6 +175,17 @@ class ConfigDictTests(unittest.TestCase):
         for name, value in config.items():
             self.assertIsInstance(name, str, f'key {name} is not a string')
 
+
+class EnableRestartTests(unittest.TestCase):
+
+    def assert_dict_in_and_equal(self, source_dict, target_dict):
+        for name, item in source_dict.items():
+            self.assertIn(name, target_dict)
+            if isinstance(item, dict):
+                self.assert_dict_in_and_equal(item, target_dict[name])
+            else:
+                self.assertEqual(item, target_dict[name])
+
     def test_enable_restart_from_default(self):
         config = get_default_config()
         restart_config = enable_restart(config)
@@ -194,14 +205,6 @@ class ConfigDictTests(unittest.TestCase):
         with self.assertRaises(ConfigError):
             enable_restart(empty_dict)
 
-    def assert_dict_in_and_equal(self, source_dict, target_dict):
-        for name, item in source_dict.items():
-            self.assertIn(name, target_dict)
-            if isinstance(item, dict):
-                self.assert_dict_in_and_equal(item, target_dict[name])
-            else:
-                self.assertEqual(item, target_dict[name])
-
     def test_enable_restart_makes_copy(self):
         config = get_default_config()
         restart_config = enable_restart(config)
@@ -209,6 +212,7 @@ class ConfigDictTests(unittest.TestCase):
         restart_config['initial_conditions'] = 'changed item'
         restart_config['namelist']['fv_core_nml']['npx'] = 0
         self.assertEqual(config, get_default_config())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Closes #24 

Adds documentation for `enable_restart` which was introduced in #9 without docs. Also improves organization of unit tests for `enable_restart` by adding them to a new TestClass and changing order of functions for clarity.