### PR TITLE
added get_n_processes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,8 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            python setup.py test
+            pip install -e .
+            pytest
 
       - store_artifacts:
           path: test-reports

--- a/fv3config/__init__.py
+++ b/fv3config/__init__.py
@@ -4,7 +4,7 @@
 
 from ._config import (
     config_to_namelist, config_from_namelist, get_default_config,
-    write_run_directory, enable_restart
+    write_run_directory, enable_restart, get_n_processes
 )
 from ._exceptions import InvalidFileError, ConfigError
 from ._datastore import ensure_data_is_downloaded

--- a/fv3config/_config.py
+++ b/fv3config/_config.py
@@ -19,6 +19,11 @@ namelist_options_dict = {
     'default': os.path.join(package_directory, 'data/namelist/default.nml')
 }
 
+_DEFAULTS = {
+    'ntiles': 6,
+    'layout': (1, 1),
+}
+
 
 def get_default_config():
     """Returns a default model configuration dictionary."""
@@ -31,6 +36,16 @@ def get_default_config():
     config['experiment_name'] = 'default_experiment'
 
     return config
+
+
+def get_n_processes(config_dict):
+    """Return the number of processes required to run the model based on the
+    configured processor layout.
+    """
+    n_tiles = config_dict['namelist']['fv_core_nml'].get('ntiles', _DEFAULTS['ntiles'])
+    layout = config_dict['namelist']['fv_core_nml'].get('layout', _DEFAULTS['layout'])
+    processors_per_tile = layout[0] * layout[1]
+    return n_tiles * processors_per_tile
 
 
 def config_to_namelist(config, namelist_filename):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,3 +13,4 @@ appdirs>=1.4.0
 requests
 sphinx_rtd_theme
 gsutil
+pytest

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requirements = [
 setup_requirements = [
 ]
 
-test_requirements = [ ]
+test_requirements = ['pytest']
 
 setup(
     author="Vulcan Technologies LLC",

--- a/tests/test_n_processes.py
+++ b/tests/test_n_processes.py
@@ -1,0 +1,24 @@
+import fv3config
+import pytest
+
+
+@pytest.mark.parametrize(
+    "ntiles,layout,expected",
+    [
+        (6, (1, 1), 6),
+        (6, (2, 2), 24),
+        (6, (2, 3), 36),
+        (1, (3, 3), 9),
+    ]
+)
+def test_get_n_processes(ntiles, layout, expected):
+    config_dict = {
+        'namelist': {
+            'fv_core_nml': {
+                'ntiles': ntiles,
+                'layout': layout,
+            }
+        }
+    }
+    result = fv3config.get_n_processes(config_dict)
+    assert result == expected


### PR DESCRIPTION
Added a `get_n_processes` helper function. It includes a docstring that will show up in the autodoc documentation, and tests.

While doing this, I also moved the test handling over to pytest.

Ran over the checklist and I think it's all there.