### PR TITLE
added support for bind-mounting local files in run_docker

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -89,6 +89,30 @@ Some helper functions exist for editing and retrieving information from configur
 dictionaries, like :py:func:`fv3config.get_run_duration` and
 :py:func:`fv3config.set_run_duration`. See the :ref:`API Reference` for more details.
 
+Specifying individual files
+---------------------------
+
+More fine-grained control of the files that are written to the run-directory is possible using the "asset"
+representation of run-directory files. An asset is a dictionary that knows about one files's source
+location/filename, target filename, target location within the run directory and whether that file is copied or linked.
+Asset dicts can be generated with the helper function :py:func:`fv3config.get_asset_dict`. For example::
+
+    >>> get_asset_dict('/path/to/filedir/', 'sample_file.nc', target_location='INPUT/')
+    {'source_location': '/path/to/filedir/',
+    'source_name': 'sample_file.nc',
+    'target_location': 'INPUT/',
+    'target_name': 'sample_file.nc',
+    'copy_method': 'copy'}
+
+One can set ``config['initial_conditions']`` or ``config['forcing']``
+to a list of assets in order to specify every initial condition or forcing file individually.
+
+One can use a directory to specify the initial conditions or forcing files and replace only a
+subset of the files within the that directory with the optional ``config['patch_files']`` item.
+All assets defined in ``config['patch_files']`` will overwrite any files specified in the
+initial conditions or forcing if they have the same target location and name.
+
+
 Running the model with fv3run
 -----------------------------
 
@@ -183,29 +207,6 @@ based on the default configuration dictionary::
 The gcp key is generally necessary to gain permissions to read and write from google
 cloud storage buckets. In the unlikely case that you are writing to a public bucket,
 it can be ommitted.
-
-Specifying individual files
----------------------------
-
-More fine-grained control of the files that are written to the run-directory is possible using the "asset"
-representation of run-directory files. An asset is a dictionary that knows about one files's source
-location/filename, target filename, target location within the run directory and whether that file is copied or linked.
-Asset dicts can be generated with the helper function :py:func:`fv3config.get_asset_dict`. For example::
-
-    >>> get_asset_dict('/path/to/filedir/', 'sample_file.nc', target_location='INPUT/')
-    {'source_location': '/path/to/filedir/',
-    'source_name': 'sample_file.nc',
-    'target_location': 'INPUT/',
-    'target_name': 'sample_file.nc',
-    'copy_method': 'copy'}
-
-One can set ``config['initial_conditions']`` or ``config['forcing']``
-to a list of assets in order to specify every initial condition or forcing file individually.
-
-One can use a directory to specify the initial conditions or forcing files and replace only a
-subset of the files within the that directory with the optional ``config['patch_files']`` item.
-All assets defined in ``config['patch_files']`` will overwrite any files specified in the
-initial conditions or forcing if they have the same target location and name.
 
 Restart runs
 ------------

--- a/fv3config/fv3run/_docker.py
+++ b/fv3config/fv3run/_docker.py
@@ -102,15 +102,17 @@ def _get_paths(config_dict):
     return return_list
 
 
+def _is_local_path(maybe_path_or_object):
+    return (isinstance(maybe_path_or_object, str)
+            and os.path.isabs(maybe_path_or_object)
+            and filesystem._is_local_path(maybe_path_or_object))
+
+
 def _get_local_data_paths(config_dict):
     """Return a list of all local paths referenced by the config dict."""
     local_paths = []
     for potential_path in _get_paths(config_dict):
-        if (
-            isinstance(potential_path, str)
-            and os.path.isabs(potential_path)
-            and filesystem._is_local_path(potential_path)
-        ):
+        if _is_local_path(potential_path):
             local_paths.append(potential_path)
         elif isinstance(potential_path, list):
             for asset in potential_path:
@@ -118,6 +120,12 @@ def _get_local_data_paths(config_dict):
                     local_paths.append(
                         os.path.join(asset["source_location"], asset["source_name"])
                     )
+        elif isinstance(potential_path, dict):
+            asset = potential_path
+            if filesystem._is_local_path(asset["source_location"]):
+                local_paths.append(
+                    os.path.join(asset["source_location"], asset["source_name"])
+                )
     return local_paths
 
 

--- a/fv3config/fv3run/_docker.py
+++ b/fv3config/fv3run/_docker.py
@@ -3,7 +3,7 @@ import subprocess
 import os
 from .. import filesystem
 from ..config import config_to_yaml
-from ._native import CONFIG_OUT_FILENAME
+from ._native import CONFIG_OUT_FILENAME, _get_config_dict_and_write
 
 DOCKER_OUTDIR = "/outdir"
 DOCKER_CONFIG_LOCATION = os.path.join("/", CONFIG_OUT_FILENAME)
@@ -72,6 +72,8 @@ def _get_python_command(config_location, outdir):
 
 
 def _get_config_args(config_dict_or_location, config_tempfile, bind_mount_args):
+    config_dict = _get_config_dict_and_write(
+        config_dict_or_location, config_tempfile.name)
     if isinstance(config_dict_or_location, str):
         if filesystem._is_local_path(config_dict_or_location):
             bind_mount_args += [
@@ -82,10 +84,39 @@ def _get_config_args(config_dict_or_location, config_tempfile, bind_mount_args):
         else:
             config_location = config_dict_or_location
     else:
-        config_to_yaml(config_dict_or_location, config_tempfile.name)
         bind_mount_args += ["-v", f"{config_tempfile.name}:{DOCKER_CONFIG_LOCATION}"]
         config_location = DOCKER_CONFIG_LOCATION
+    _get_local_data_bind_mounts(config_dict, bind_mount_args)
     return config_location
+
+
+def _get_local_data_paths(config_dict):
+    """Return a list of all local paths referenced by the config dict."""
+    local_paths = []
+    for potential_path in (
+            [config_dict['diag_table'], config_dict['data_table'],
+             config_dict['forcing'], config_dict['initial_conditions']
+             ] + list(config_dict.get('patch_files', []))):
+        if (isinstance(potential_path, str) and
+                os.path.isabs(potential_path) and
+                filesystem._is_local_path(potential_path)):
+            local_paths.append(potential_path)
+        elif isinstance(potential_path, list):
+            for asset in potential_path:
+                if filesystem._is_local_path(asset['source_location']):
+                    print(asset.keys())
+                    local_paths.append(
+                        os.path.join(
+                            asset['source_location'],
+                            asset['source_name']
+                        )
+                    )
+    return local_paths
+
+
+def _get_local_data_bind_mounts(config_dict, bind_mount_args):
+    for local_path in _get_local_data_paths(config_dict):
+        bind_mount_args += ["-v", f"{local_path}:{local_path}"]
 
 
 def _get_docker_args(docker_args, bind_mount_args, outdir):

--- a/fv3config/fv3run/_docker.py
+++ b/fv3config/fv3run/_docker.py
@@ -90,15 +90,22 @@ def _get_config_args(config_dict_or_location, config_tempfile, bind_mount_args):
     return config_location
 
 
-def _get_local_data_paths(config_dict):
-    """Return a list of all local paths referenced by the config dict."""
-    local_paths = []
-    for potential_path in [
+def _get_paths(config_dict):
+    """Return a list of all paths referenced by the config dict."""
+    return_list = [
         config_dict["diag_table"],
         config_dict["data_table"],
         config_dict["forcing"],
         config_dict["initial_conditions"],
-    ] + list(config_dict.get("patch_files", [])):
+    ]
+    return_list.extend(config_dict.get("patch_files", []))
+    return return_list
+
+
+def _get_local_data_paths(config_dict):
+    """Return a list of all local paths referenced by the config dict."""
+    local_paths = []
+    for potential_path in _get_paths(config_dict):
         if (
             isinstance(potential_path, str)
             and os.path.isabs(potential_path)
@@ -108,7 +115,6 @@ def _get_local_data_paths(config_dict):
         elif isinstance(potential_path, list):
             for asset in potential_path:
                 if filesystem._is_local_path(asset["source_location"]):
-                    print(asset.keys())
                     local_paths.append(
                         os.path.join(asset["source_location"], asset["source_name"])
                     )

--- a/fv3config/fv3run/_docker.py
+++ b/fv3config/fv3run/_docker.py
@@ -2,7 +2,6 @@ import tempfile
 import subprocess
 import os
 from .. import filesystem
-from ..config import config_to_yaml
 from ._native import CONFIG_OUT_FILENAME, _get_config_dict_and_write
 
 DOCKER_OUTDIR = "/outdir"
@@ -73,7 +72,8 @@ def _get_python_command(config_location, outdir):
 
 def _get_config_args(config_dict_or_location, config_tempfile, bind_mount_args):
     config_dict = _get_config_dict_and_write(
-        config_dict_or_location, config_tempfile.name)
+        config_dict_or_location, config_tempfile.name
+    )
     if isinstance(config_dict_or_location, str):
         if filesystem._is_local_path(config_dict_or_location):
             bind_mount_args += [
@@ -93,23 +93,24 @@ def _get_config_args(config_dict_or_location, config_tempfile, bind_mount_args):
 def _get_local_data_paths(config_dict):
     """Return a list of all local paths referenced by the config dict."""
     local_paths = []
-    for potential_path in (
-            [config_dict['diag_table'], config_dict['data_table'],
-             config_dict['forcing'], config_dict['initial_conditions']
-             ] + list(config_dict.get('patch_files', []))):
-        if (isinstance(potential_path, str) and
-                os.path.isabs(potential_path) and
-                filesystem._is_local_path(potential_path)):
+    for potential_path in [
+        config_dict["diag_table"],
+        config_dict["data_table"],
+        config_dict["forcing"],
+        config_dict["initial_conditions"],
+    ] + list(config_dict.get("patch_files", [])):
+        if (
+            isinstance(potential_path, str)
+            and os.path.isabs(potential_path)
+            and filesystem._is_local_path(potential_path)
+        ):
             local_paths.append(potential_path)
         elif isinstance(potential_path, list):
             for asset in potential_path:
-                if filesystem._is_local_path(asset['source_location']):
+                if filesystem._is_local_path(asset["source_location"]):
                     print(asset.keys())
                     local_paths.append(
-                        os.path.join(
-                            asset['source_location'],
-                            asset['source_name']
-                        )
+                        os.path.join(asset["source_location"], asset["source_name"])
                     )
     return local_paths
 

--- a/fv3config/fv3run/_docker.py
+++ b/fv3config/fv3run/_docker.py
@@ -103,9 +103,11 @@ def _get_paths(config_dict):
 
 
 def _is_local_path(maybe_path_or_object):
-    return (isinstance(maybe_path_or_object, str)
-            and os.path.isabs(maybe_path_or_object)
-            and filesystem._is_local_path(maybe_path_or_object))
+    return (
+        isinstance(maybe_path_or_object, str)
+        and os.path.isabs(maybe_path_or_object)
+        and filesystem._is_local_path(maybe_path_or_object)
+    )
 
 
 def _get_local_data_paths(config_dict):

--- a/fv3config/fv3run/_docker.py
+++ b/fv3config/fv3run/_docker.py
@@ -98,7 +98,11 @@ def _get_paths(config_dict):
         config_dict["forcing"],
         config_dict["initial_conditions"],
     ]
-    return_list.extend(config_dict.get("patch_files", []))
+    patch_files = config_dict.get("patch_files", [])
+    if isinstance(patch_files, list):
+        return_list.extend(patch_files)
+    else:
+        return_list.append(patch_files)
     return return_list
 
 

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -369,7 +369,7 @@ def test_get_credentials_args(keyfile, expected_docker_args, expected_bind_mount
                     }
                 ],
                 "data_table": "gs://bucket/data_table/default",
-                "patch_files": []
+                "patch_files": [],
             },
             [],
         ],
@@ -413,15 +413,17 @@ def test_get_credentials_args(keyfile, expected_docker_args, expected_bind_mount
                     }
                 ],
                 "data_table": "gs://bucket/data_table/default",
-                "patch_files": [{
-                    "source_location": "/local/directory",
-                    "source_name": "source_name.nc",
-                    "target_location": "INPUT/",
-                    "target_name": "filename.nc",
-                    "copy_method": "copy",
-                }],
+                "patch_files": [
+                    {
+                        "source_location": "/local/directory",
+                        "source_name": "source_name.nc",
+                        "target_location": "INPUT/",
+                        "target_name": "filename.nc",
+                        "copy_method": "copy",
+                    }
+                ],
             },
-            ['/local/directory/source_name.nc'],
+            ["/local/directory/source_name.nc"],
         ],
     ],
 )

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -322,19 +322,19 @@ def test_get_credentials_args(keyfile, expected_docker_args, expected_bind_mount
             {
                 "experiment_name": "default_experiment",
                 "initial_conditions": "gs://bucket/initial_conditions/default",
-                "forcing": "gs://bucket/forcing/default",
-                "diag_table": [
+                "forcing": [
                     {
                         "source_location": "/local/directory",
-                        "source_name": "source_namename.nc",
+                        "source_name": "source_name.nc",
                         "target_location": "INPUT/",
                         "target_name": "filename.nc",
                         "copy_method": "copy",
                     }
                 ],
+                "diag_table": "/local/diag/default",
                 "data_table": "gs://bucket/data_table/default",
             },
-            ["/local/directory/source_namename.nc"],
+            ["/local/directory/source_name.nc", "/local/diag/default"],
         ],
         [
             {
@@ -344,7 +344,7 @@ def test_get_credentials_args(keyfile, expected_docker_args, expected_bind_mount
                 "diag_table": [
                     {
                         "source_location": "gs://remote/directory",
-                        "source_name": "source_namename.nc",
+                        "source_name": "source_name.nc",
                         "target_location": "INPUT/",
                         "target_name": "filename.nc",
                         "copy_method": "copy",
@@ -353,6 +353,75 @@ def test_get_credentials_args(keyfile, expected_docker_args, expected_bind_mount
                 "data_table": "gs://bucket/data_table/default",
             },
             [],
+        ],
+        [
+            {
+                "experiment_name": "default_experiment",
+                "initial_conditions": "gs://bucket/initial_conditions/default",
+                "forcing": "gs://bucket/forcing/default",
+                "diag_table": [
+                    {
+                        "source_location": "gs://remote/directory",
+                        "source_name": "source_name.nc",
+                        "target_location": "INPUT/",
+                        "target_name": "filename.nc",
+                        "copy_method": "copy",
+                    }
+                ],
+                "data_table": "gs://bucket/data_table/default",
+                "patch_files": []
+            },
+            [],
+        ],
+        [
+            {
+                "experiment_name": "default_experiment",
+                "initial_conditions": "gs://bucket/initial_conditions/default",
+                "forcing": "gs://bucket/forcing/default",
+                "diag_table": [
+                    {
+                        "source_location": "gs://remote/directory",
+                        "source_name": "source_name.nc",
+                        "target_location": "INPUT/",
+                        "target_name": "filename.nc",
+                        "copy_method": "copy",
+                    }
+                ],
+                "data_table": "gs://bucket/data_table/default",
+                "patch_files": {
+                    "source_location": "gs://remote/directory",
+                    "source_name": "source_name.nc",
+                    "target_location": "INPUT/",
+                    "target_name": "filename.nc",
+                    "copy_method": "copy",
+                },
+            },
+            [],
+        ],
+        [
+            {
+                "experiment_name": "default_experiment",
+                "initial_conditions": "gs://bucket/initial_conditions/default",
+                "forcing": "gs://bucket/forcing/default",
+                "diag_table": [
+                    {
+                        "source_location": "gs://remote/directory",
+                        "source_name": "source_name.nc",
+                        "target_location": "INPUT/",
+                        "target_name": "filename.nc",
+                        "copy_method": "copy",
+                    }
+                ],
+                "data_table": "gs://bucket/data_table/default",
+                "patch_files": [{
+                    "source_location": "/local/directory",
+                    "source_name": "source_name.nc",
+                    "target_location": "INPUT/",
+                    "target_name": "filename.nc",
+                    "copy_method": "copy",
+                }],
+            },
+            ['/local/directory/source_name.nc'],
         ],
     ],
 )

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -188,6 +188,16 @@ def test_get_runfile_args(runfile, expected_bind_mount_args, expected_python_arg
     assert python_args == expected_python_args
 
 
+_original_get_file = fv3config.filesystem.get_file
+
+
+def maybe_get_file(*args, **kwargs):
+    try:
+        _original_get_file(*args, **kwargs)
+    except OSError:
+        pass
+
+
 @pytest.mark.parametrize(
     "config, tempfile, expected_config_location, expected_bind_mount_args",
     [
@@ -212,14 +222,16 @@ def test_get_runfile_args(runfile, expected_bind_mount_args, expected_python_arg
     ],
 )
 def test_get_config_args(
-    config, tempfile, expected_config_location, expected_bind_mount_args
-):
-    bind_mount_args = []
-    config_location = fv3config.fv3run._docker._get_config_args(
-        config, tempfile, bind_mount_args
-    )
-    assert config_location == expected_config_location
-    assert bind_mount_args == expected_bind_mount_args
+        config, tempfile, expected_config_location, expected_bind_mount_args):
+    # paths don't actually exist, but that doesn't matter for this test
+    # use mock to ignore the "not found" errors
+    with unittest.mock.patch("fv3config.filesystem.get_file", new=maybe_get_file):
+        bind_mount_args = []
+        config_location = fv3config.fv3run._docker._get_config_args(
+            config, tempfile, bind_mount_args
+        )
+        assert config_location == expected_config_location
+        assert bind_mount_args == expected_bind_mount_args
 
 
 @pytest.mark.parametrize(
@@ -265,3 +277,75 @@ def test_get_credentials_args(keyfile, expected_docker_args, expected_bind_mount
     )
     assert docker_args == expected_docker_args
     assert bind_mount_args == expected_bind_mount_args
+
+
+@pytest.mark.parametrize(
+    "config_dict, local_paths",
+    [
+        [
+            {
+                'experiment_name': 'default_experiment',
+                'initial_conditions': 'default',
+                'forcing': 'gs://bucket/forcing/default',
+                'diag_table': 'gs://bucket/diag/default',
+                'data_table': 'gs://bucket/data_table/default',
+            },
+            []
+        ],
+        [
+            {
+                'experiment_name': 'default_experiment',
+                'initial_conditions': '/local/initial/conditions',
+                'forcing': 'gs://bucket/forcing/default',
+                'diag_table': 'gs://bucket/diag/default',
+                'data_table': 'gs://bucket/data_table/default',
+            },
+            ["/local/initial/conditions"]
+        ],
+        [
+            {
+                'experiment_name': 'default_experiment',
+                'initial_conditions': '/local/initial/conditions',
+                'forcing': '/local/forcing/default',
+                'diag_table': '/local/diag/default',
+                'data_table': 'gs://bucket/data_table/default',
+            },
+            ["/local/initial/conditions", "/local/forcing/default", '/local/diag/default']
+        ],
+        [
+            {
+                'experiment_name': 'default_experiment',
+                'initial_conditions': 'gs://bucket/initial_conditions/default',
+                'forcing': 'gs://bucket/forcing/default',
+                'diag_table': [{
+                    'source_location': '/local/directory',
+                    'source_name': 'source_namename.nc',
+                    'target_location': 'INPUT/',
+                    'target_name': 'filename.nc',
+                    'copy_method': 'copy',
+                }],
+                'data_table': 'gs://bucket/data_table/default',
+            },
+            ['/local/directory/source_namename.nc']
+        ],
+        [
+            {
+                'experiment_name': 'default_experiment',
+                'initial_conditions': 'gs://bucket/initial_conditions/default',
+                'forcing': 'gs://bucket/forcing/default',
+                'diag_table': [{
+                    'source_location': 'gs://remote/directory',
+                    'source_name': 'source_namename.nc',
+                    'target_location': 'INPUT/',
+                    'target_name': 'filename.nc',
+                    'copy_method': 'copy',
+                }],
+                'data_table': 'gs://bucket/data_table/default',
+            },
+            []
+        ],
+    ]
+)
+def test_get_local_paths(config_dict, local_paths):
+    return_value = fv3config.fv3run._docker._get_local_data_paths(config_dict)
+    assert set(return_value) == set(local_paths)  # order does not matter

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -8,6 +8,7 @@ import collections
 import subprocess
 import pytest
 import yaml
+import gcsfs
 import fv3config
 
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -194,7 +195,7 @@ _original_get_file = fv3config.filesystem.get_file
 def maybe_get_file(*args, **kwargs):
     try:
         _original_get_file(*args, **kwargs)
-    except OSError:
+    except (OSError, gcsfs.utils.HttpError):
         pass
 
 
@@ -222,7 +223,8 @@ def maybe_get_file(*args, **kwargs):
     ],
 )
 def test_get_config_args(
-        config, tempfile, expected_config_location, expected_bind_mount_args):
+    config, tempfile, expected_config_location, expected_bind_mount_args
+):
     # paths don't actually exist, but that doesn't matter for this test
     # use mock to ignore the "not found" errors
     with unittest.mock.patch("fv3config.filesystem.get_file", new=maybe_get_file):
@@ -284,67 +286,75 @@ def test_get_credentials_args(keyfile, expected_docker_args, expected_bind_mount
     [
         [
             {
-                'experiment_name': 'default_experiment',
-                'initial_conditions': 'default',
-                'forcing': 'gs://bucket/forcing/default',
-                'diag_table': 'gs://bucket/diag/default',
-                'data_table': 'gs://bucket/data_table/default',
+                "experiment_name": "default_experiment",
+                "initial_conditions": "default",
+                "forcing": "gs://bucket/forcing/default",
+                "diag_table": "gs://bucket/diag/default",
+                "data_table": "gs://bucket/data_table/default",
             },
-            []
+            [],
         ],
         [
             {
-                'experiment_name': 'default_experiment',
-                'initial_conditions': '/local/initial/conditions',
-                'forcing': 'gs://bucket/forcing/default',
-                'diag_table': 'gs://bucket/diag/default',
-                'data_table': 'gs://bucket/data_table/default',
+                "experiment_name": "default_experiment",
+                "initial_conditions": "/local/initial/conditions",
+                "forcing": "gs://bucket/forcing/default",
+                "diag_table": "gs://bucket/diag/default",
+                "data_table": "gs://bucket/data_table/default",
             },
-            ["/local/initial/conditions"]
+            ["/local/initial/conditions"],
         ],
         [
             {
-                'experiment_name': 'default_experiment',
-                'initial_conditions': '/local/initial/conditions',
-                'forcing': '/local/forcing/default',
-                'diag_table': '/local/diag/default',
-                'data_table': 'gs://bucket/data_table/default',
+                "experiment_name": "default_experiment",
+                "initial_conditions": "/local/initial/conditions",
+                "forcing": "/local/forcing/default",
+                "diag_table": "/local/diag/default",
+                "data_table": "gs://bucket/data_table/default",
             },
-            ["/local/initial/conditions", "/local/forcing/default", '/local/diag/default']
+            [
+                "/local/initial/conditions",
+                "/local/forcing/default",
+                "/local/diag/default",
+            ],
         ],
         [
             {
-                'experiment_name': 'default_experiment',
-                'initial_conditions': 'gs://bucket/initial_conditions/default',
-                'forcing': 'gs://bucket/forcing/default',
-                'diag_table': [{
-                    'source_location': '/local/directory',
-                    'source_name': 'source_namename.nc',
-                    'target_location': 'INPUT/',
-                    'target_name': 'filename.nc',
-                    'copy_method': 'copy',
-                }],
-                'data_table': 'gs://bucket/data_table/default',
+                "experiment_name": "default_experiment",
+                "initial_conditions": "gs://bucket/initial_conditions/default",
+                "forcing": "gs://bucket/forcing/default",
+                "diag_table": [
+                    {
+                        "source_location": "/local/directory",
+                        "source_name": "source_namename.nc",
+                        "target_location": "INPUT/",
+                        "target_name": "filename.nc",
+                        "copy_method": "copy",
+                    }
+                ],
+                "data_table": "gs://bucket/data_table/default",
             },
-            ['/local/directory/source_namename.nc']
+            ["/local/directory/source_namename.nc"],
         ],
         [
             {
-                'experiment_name': 'default_experiment',
-                'initial_conditions': 'gs://bucket/initial_conditions/default',
-                'forcing': 'gs://bucket/forcing/default',
-                'diag_table': [{
-                    'source_location': 'gs://remote/directory',
-                    'source_name': 'source_namename.nc',
-                    'target_location': 'INPUT/',
-                    'target_name': 'filename.nc',
-                    'copy_method': 'copy',
-                }],
-                'data_table': 'gs://bucket/data_table/default',
+                "experiment_name": "default_experiment",
+                "initial_conditions": "gs://bucket/initial_conditions/default",
+                "forcing": "gs://bucket/forcing/default",
+                "diag_table": [
+                    {
+                        "source_location": "gs://remote/directory",
+                        "source_name": "source_namename.nc",
+                        "target_location": "INPUT/",
+                        "target_name": "filename.nc",
+                        "copy_method": "copy",
+                    }
+                ],
+                "data_table": "gs://bucket/data_table/default",
             },
-            []
+            [],
         ],
-    ]
+    ],
 )
 def test_get_local_paths(config_dict, local_paths):
     return_value = fv3config.fv3run._docker._get_local_data_paths(config_dict)


### PR DESCRIPTION
Fixes #48. Bind-mounts at the same level as specified by the config dict (directories if absolute path, filename if asset dict).

A side-effect of this is that calling run_docker will trigger an access request on the configuration dictionary. If the user does not have access, the command will fail (not really an issue, since it would also fail inside the docker container in that case). This did require mocking out the access in some other unit tests.

No documentation change needed as the lack of support for bind-mounting local files was undocumented. I did shift one documentation section at the suggestion of @oliverwm1 to make the order of information smoother.

Tests that the correct locations are bind-mounted are added.