### PR TITLE
Only use --oversubscribe flag if cpu count requires it

### DIFF
--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -1,4 +1,5 @@
 import os
+import re
 import uuid
 from .._exceptions import DelayedImportError
 from .. import filesystem

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -117,7 +117,7 @@ def _submit_job(job, namespace):
 
 def _create_job_object(config_location, outdir, docker_image, runfile, kube_config):
     container = kube.client.V1Container(
-        name=os.path.basename(docker_image),
+        name=_get_name_from_image(docker_image),
         image=docker_image,
         image_pull_policy=kube_config.image_pull_policy,
         command=_get_kube_command(config_location, outdir, runfile),
@@ -126,6 +126,11 @@ def _create_job_object(config_location, outdir, docker_image, runfile, kube_conf
         env=kube_config.env,
     )
     return _container_to_job(container, kube_config)
+
+
+def _get_name_from_image(docker_image):
+    name = os.path.basename(docker_image)
+    return re.split("\W+", name)[0]
 
 
 def _get_kube_command(config_location, outdir, runfile=None):

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -131,7 +131,7 @@ def _create_job_object(config_location, outdir, docker_image, runfile, kube_conf
 
 def _get_name_from_image(docker_image):
     name = os.path.basename(docker_image)
-    return re.split("\W+", name)[0]
+    return re.split(r"\W+", name)[0]
 
 
 def _get_kube_command(config_location, outdir, runfile=None):

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -72,7 +72,10 @@ def _add_oversubscribe_if_necessary(mpi_flags, n_processes):
         if cpu_count < n_processes:
             mpi_flags += ["--oversubscribe"]
     except NotImplementedError:
-        warnings.warn("could not determine cpu count, assuming it is sufficient")
+        warnings.warn(
+            "could not determine cpu count, assuming number of processors"
+            "is at least as many as number of MPI tasks"
+        )
     return mpi_flags
 
 

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -12,7 +12,7 @@ from .. import filesystem
 STDOUT_FILENAME = "stdout.log"
 STDERR_FILENAME = "stderr.log"
 CONFIG_OUT_FILENAME = "fv3config.yml"
-MPI_FLAGS = ["--allow-run-as-root", "--oversubscribe"]
+MPI_FLAGS = ["--allow-run-as-root"]
 
 logger = logging.getLogger("fv3run")
 

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -12,7 +12,7 @@ from .. import filesystem
 STDOUT_FILENAME = "stdout.log"
 STDERR_FILENAME = "stderr.log"
 CONFIG_OUT_FILENAME = "fv3config.yml"
-MPI_FLAGS = ["--allow-run-as-root"]
+MPI_FLAGS = ["--allow-run-as-root", "--use-hwthread-cpus"]
 
 logger = logging.getLogger("fv3run")
 

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -72,8 +72,7 @@ def _add_oversubscribe_if_necessary(mpi_flags, n_processes):
         if cpu_count < n_processes:
             mpi_flags += ['--oversubscribe']
     except NotImplementedError:
-        warnings.warn("could not determine cpu count, using --oversubscribe in case")
-        mpi_flags += ['--oversubscribe']
+        warnings.warn("could not determine cpu count, assuming it is sufficient")
     return mpi_flags
 
 

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -70,11 +70,10 @@ def _add_oversubscribe_if_necessary(mpi_flags, n_processes):
     try:
         cpu_count = multiprocessing.cpu_count()
         if cpu_count < n_processes:
-            mpi_flags += ['--oversubscribe']
+            mpi_flags += ["--oversubscribe"]
     except NotImplementedError:
         warnings.warn("could not determine cpu count, assuming it is sufficient")
     return mpi_flags
-
 
 
 @contextlib.contextmanager

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -118,7 +118,7 @@ def test_fv3run_with_mocked_subprocess(runner):
                 "-n",
                 "6",
                 "--allow-run-as-root",
-                "--oversubscribe",
+                "--use-hwthread-cpus",
                 "python3",
                 "-m",
                 "mpi4py",


### PR DESCRIPTION
This PR ensures the `--oversubscribe` MPI flag is only used if the CPU count requires it. It adds the `--use-hwthread-cpus` flag so that hyperthreaded cores (such as on google VMs and MacBooks) will be used.

It also fixes a bug in `_create_job_object` by ensuring that the container name is alphanumeric.