### PR TITLE
Instructions on incrementing and tagging a version

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,14 @@
 History
 =======
 
+
+0.2.0 (2020-01-27)
+------------------
+
+* Began tagging version commits
+
+
 0.1.0 (2019-10-11)
 ------------------
 
-* First release on PyPI.
+* Initial pre-alpha release

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,10 @@
+Release Instructions
+====================
+
+1. Prepare master branch for release (make sure all PRs are merged and tests pass).
+
+2. Run `bumpversion <major/minor/bugfix>`. This will create a new tagged commit,
+   having updated all version references to the new, higher version.
+
+3. Run `git push && git push origin --tags` to push the version reference commit and
+   then all local tags to master.


### PR DESCRIPTION
Added a RELEASE.rst file with release instructions. For us right now that means incrementing the version, tagging a commit, and pushing it to master. Further down the line this file can include instructions on deploying to pypi.