### PR TITLE
Fix test_fv3run for oversubscribed testing system

### DIFF
--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -113,7 +113,13 @@ def test_fv3run_with_mocked_subprocess(runner):
     ):
         runner(fv3config.get_default_config(), outdir)
         assert mock.called
-        assert mock.call_args[0] == (
+        call_args = list(mock.call_args[0])
+        # ensure test does not depend on # of processors on testing system
+        try:
+            call_args.remove('--oversubscribe')
+        except ValueError:
+            pass
+        assert call_args == [
             [
                 "mpirun",
                 "-n",
@@ -125,7 +131,7 @@ def test_fv3run_with_mocked_subprocess(runner):
                 "mpi4py",
                 "mock_runscript.py",
             ],
-        )
+        ]
         config = yaml.safe_load(open(os.path.join(outdir, "fv3config.yml"), "r"))
         assert config == fv3config.get_default_config()
 

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -115,10 +115,8 @@ def test_fv3run_with_mocked_subprocess(runner):
         assert mock.called
         call_args = list(mock.call_args[0])
         # ensure test does not depend on # of processors on testing system
-        try:
+        while "--oversubscribe" in call_args[0]:
             call_args[0].remove("--oversubscribe")
-        except ValueError:
-            pass
         assert call_args == [
             [
                 "mpirun",

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -116,7 +116,7 @@ def test_fv3run_with_mocked_subprocess(runner):
         call_args = list(mock.call_args[0])
         # ensure test does not depend on # of processors on testing system
         try:
-            call_args.remove('--oversubscribe')
+            call_args.remove("--oversubscribe")
         except ValueError:
             pass
         assert call_args == [

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -116,7 +116,7 @@ def test_fv3run_with_mocked_subprocess(runner):
         call_args = list(mock.call_args[0])
         # ensure test does not depend on # of processors on testing system
         try:
-            call_args.remove("--oversubscribe")
+            call_args[0].remove("--oversubscribe")
         except ValueError:
             pass
         assert call_args == [


### PR DESCRIPTION
This fixes `test_fv3run_with_mocked_subprocess` to account for the case where the testing system is oversubscribed, and hence `--oversubscribe` is created as a flag to be passed to mpirun.