### PR TITLE
Optionally specify runfile with the environmental variable

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -172,8 +172,21 @@ container based on the given image name. This assumes the ``fv3config`` package 
 ``fv3gfs`` python wrapper are installed inside the container, along with any
 dependencies.
 
+
 The python interface is very similar to the command-line interface, but is split into
 separate functions based on where the model is being run.
+
+Customizing the model execution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``runfile`` is the python script that will be executed by mpi, which
+typically imports the ``fv3gfs`` module, and then performs some time stepping.
+For maximum flexibility, a custom runfile can be specified as an argument to all the
+``run_`` functions, or by a pointing the environmental variable
+``FV3_PYTHON_RUNFILE`` to a runfile. This latter specification, is useful for
+prognostic ML runs, where the runfile will be added to a certain path inside a
+custom docker image. If no runfile is specified, a sane default is provided
+that will exactly emulate the behavior of the fortran model.
 
 Submitting a Kubernetes job
 ---------------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -187,14 +187,14 @@ flexibility a custom runfile can be specified as an argument to all the ``run_``
 functions.
 
 The default behavior is overriden if the environmental variable
-``FV3_PYTHON_RUNFILE`` is set in the execution environment. If set, this
-variable should contain the path of the runfile.
+ ``FV3CONFIG_DEFAULT_RUNFILE`` is set in the execution environment. If set, this
+ variable should contain the path of the runfile.
 
 .. note::
 
-  When using ``run_docker`` or ``run_kubernetes``, both ``FV3_PYTHON_RUNFILE``
-  and the file it points to must be present in the specified docker image. It
-  will have no effect if set on the host system.
+  When using ``run_docker`` or ``run_kubernetes``, both
+  ``FV3CONFIG_DEFAULT_RUNFILE`` and the file it points to must be present in the
+  specified docker image. It will have no effect if set on the host system.
    
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -172,7 +172,6 @@ container based on the given image name. This assumes the ``fv3config`` package 
 ``fv3gfs`` python wrapper are installed inside the container, along with any
 dependencies.
 
-
 The python interface is very similar to the command-line interface, but is split into
 separate functions based on where the model is being run.
 
@@ -181,22 +180,21 @@ Customizing the model execution
 
 The ``runfile`` is the python script that will be executed by mpi, which
 typically imports the ``fv3gfs`` module, and then performs some time stepping.
-The default behavior is to use a pre-packaged runfile ``-m fv3config.fv3run``
-which reproduces the behavior of Fortran model identically. For additional,
-flexibility a custom runfile can be specified as an argument to all the ``run_``
-functions.
+The default behavior is to use a pre-packaged runfile which reproduces the
+behavior of Fortran model identically. For additional, flexibility a custom
+runfile can be specified as an argument to all the ``run_`` functions.
 
-The default behavior is overriden if the environmental variable
- ``FV3CONFIG_DEFAULT_RUNFILE`` is set in the execution environment. If set, this
- variable should contain the path of the runfile.
+
+The environmental variable ``FV3CONFIG_DEFAULT_RUNFILE`` can be used to override
+the default runfile. If set, this variable should contain the path of the
+runfile.
 
 .. note::
 
-  When using ``run_docker`` or ``run_kubernetes``, both
-  ``FV3CONFIG_DEFAULT_RUNFILE`` and the file it points to must be present in the
-  specified docker image. It will have no effect if set on the host system.
-   
-
+  When using ``run_docker`` or ``run_kubernetes``, the value of
+  ``FV3CONFIG_DEFAULT_RUNFILE`` and the file it points to will be read inside the
+  docker image where execution occurs. It will have no effect if set on the host
+  system outside of the docker image.
 
 Submitting a Kubernetes job
 ---------------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -177,7 +177,7 @@ The python interface is very similar to the command-line interface, but is split
 separate functions based on where the model is being run.
 
 Customizing the model execution
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 
 The ``runfile`` is the python script that will be executed by mpi, which
 typically imports the ``fv3gfs`` module, and then performs some time stepping.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -181,12 +181,22 @@ Customizing the model execution
 
 The ``runfile`` is the python script that will be executed by mpi, which
 typically imports the ``fv3gfs`` module, and then performs some time stepping.
-For maximum flexibility, a custom runfile can be specified as an argument to all the
-``run_`` functions, or by a pointing the environmental variable
-``FV3_PYTHON_RUNFILE`` to a runfile. This latter specification, is useful for
-prognostic ML runs, where the runfile will be added to a certain path inside a
-custom docker image. If no runfile is specified, a sane default is provided
-that will exactly emulate the behavior of the fortran model.
+The default behavior is to use a pre-packaged runfile ``-m fv3config.fv3run``
+which reproduces the behavior of Fortran model identically. For additional,
+flexibility a custom runfile can be specified as an argument to all the ``run_``
+functions.
+
+The default behavior is overriden if the environmental variable
+``FV3_PYTHON_RUNFILE`` is set in the execution environment. If set, this
+variable should contain the path of the runfile.
+
+.. note::
+
+  When using ``run_docker`` or ``run_kubernetes``, both ``FV3_PYTHON_RUNFILE``
+  and the file it points to must be present in the specified docker image. It
+  will have no effect if set on the host system.
+   
+
 
 Submitting a Kubernetes job
 ---------------------------

--- a/fv3config/fv3run/__main__.py
+++ b/fv3config/fv3run/__main__.py
@@ -26,11 +26,8 @@ Will use google cloud storage key at $GOOGLE_APPLICATION_CREDENTIALS by default.
         "--runfile",
         type=str,
         action="store",
-        help="Location of python script to execute with mpirun. If this is not "
-        "provided, the file within the docker image pointed to be the "
-        "environmental "
-        f"variable {RUNFILE_ENV_VAR} will be used. If that variable is not "
-        "present, then the model will be run identically to the Fortran model.",
+        help="Location of python script to execute with mpirun. If not specified, a "
+             f"default is used, which can be overriden by setting the {RUNFILE_ENV_VAR}."
     )
     parser.add_argument(
         "--dockerimage",

--- a/fv3config/fv3run/__main__.py
+++ b/fv3config/fv3run/__main__.py
@@ -1,7 +1,7 @@
 import sys
 import argparse
 from ._docker import run_docker
-from ._native import run_native
+from ._native import run_native, RUNFILE_ENV_VAR
 
 MODULE_NAME = "fv3config.run"
 STDOUT_FILENAME = "stdout.log"
@@ -26,7 +26,11 @@ Will use google cloud storage key at $GOOGLE_APPLICATION_CREDENTIALS by default.
         "--runfile",
         type=str,
         action="store",
-        help="location of python script to execute with mpirun",
+        help="Location of python script to execute with mpirun. If this is not "
+        "provided, the file within the docker image pointed to be the "
+        "environmental "
+        f"variable {RUNFILE_ENV_VAR} will be used. If that variable is not "
+        "present, then the model will be run identically to the Fortran model.",
     )
     parser.add_argument(
         "--dockerimage",

--- a/fv3config/fv3run/__main__.py
+++ b/fv3config/fv3run/__main__.py
@@ -27,7 +27,7 @@ Will use google cloud storage key at $GOOGLE_APPLICATION_CREDENTIALS by default.
         type=str,
         action="store",
         help="Location of python script to execute with mpirun. If not specified, a "
-             f"default is used, which can be overriden by setting the {RUNFILE_ENV_VAR}."
+        f"default is used, which can be overriden by setting the {RUNFILE_ENV_VAR}.",
     )
     parser.add_argument(
         "--dockerimage",

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -14,6 +14,7 @@ STDOUT_FILENAME = "stdout.log"
 STDERR_FILENAME = "stderr.log"
 CONFIG_OUT_FILENAME = "fv3config.yml"
 MPI_FLAGS = ["--allow-run-as-root", "--use-hwthread-cpus"]
+RUNFILE_ENV_VAR = "FV3_PYTHON_RUNFILE"
 
 logger = logging.getLogger("fv3run")
 
@@ -50,9 +51,20 @@ def run_native(config_dict_or_location, outdir, runfile=None):
             _run_experiment(
                 localdir,
                 n_processes,
-                runfile_name=_get_basename_or_none(runfile),
+                python_args=_get_python_args(runfile),
                 mpi_flags=_add_oversubscribe_if_necessary(MPI_FLAGS, n_processes),
             )
+
+
+def _get_python_args(runfile):
+    python_args = ["python3", "-m", "mpi4py"]
+    if runfile is not None:
+        python_args.append(os.path.basename(runfile))
+    elif RUNFILE_ENV_VAR in os.environ:
+        python_args.append(os.environ[RUNFILE_ENV_VAR])
+    else:
+        python_args += ["-m", "fv3config.fv3run"]
+    return python_args
 
 
 def _set_stacksize_unlimited():
@@ -105,13 +117,9 @@ def _log_exceptions(localdir):
         raise e
 
 
-def _run_experiment(dirname, n_processes, runfile_name=None, mpi_flags=None):
+def _run_experiment(dirname, n_processes, python_args, mpi_flags=None):
     if mpi_flags is None:
         mpi_flags = []
-    if runfile_name is None:
-        python_args = ["python3", "-m", "mpi4py", "-m", "fv3gfs.run"]
-    else:
-        python_args = ["python3", "-m", "mpi4py", runfile_name]
     out_filename = os.path.join(dirname, STDOUT_FILENAME)
     err_filename = os.path.join(dirname, STDERR_FILENAME)
     with open(out_filename, "wb") as out_file, open(err_filename, "wb") as err_file:
@@ -122,13 +130,6 @@ def _run_experiment(dirname, n_processes, runfile_name=None, mpi_flags=None):
             stdout=out_file,
             stderr=err_file,
         )
-
-
-def _get_basename_or_none(runfile):
-    if runfile is None:
-        return None
-    else:
-        return os.path.basename(runfile)
 
 
 def _get_config_dict_and_write(config_dict_or_location, config_out_filename):

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -10,7 +10,7 @@ import pytest
 import yaml
 import gcsfs
 import fv3config
-from fv3config.fv3run._native import _get_python_args, RUNFILE_ENV_VAR
+from fv3config.fv3run._native import _get_python_command, RUNFILE_ENV_VAR
 
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 MOCK_RUNSCRIPT = os.path.abspath(os.path.join(TEST_DIR, "testdata/mock_runscript.py"))
@@ -210,7 +210,7 @@ def test_get_runfile_args(runfile, expected_bind_mount_args, expected_python_arg
 def test__get_native_python_args(monkeypatch, runfile, expected, env_var):
     if env_var is not None:
         monkeypatch.setenv(RUNFILE_ENV_VAR, env_var)
-    assert _get_python_args(runfile) == expected
+    assert _get_python_command(runfile) == expected
 
 
 _original_get_file = fv3config.filesystem.get_file


### PR DESCRIPTION
This allows a user to run the model with a python runfile already present in the
a docker image by setting the FV3_PYTHON_RUNFILE environmental variable. Because
the runfile is in many ways inseperable from the fortran code itself, it is
beneficial to bundle it with the other FV3 code.

Partially resolves #56 