### PR TITLE
Fix bug where fv3config calls itself infinitely

### DIFF
--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -113,7 +113,7 @@ def _get_python_command(runfile):
     elif RUNFILE_ENV_VAR in os.environ:
         python_args.append(os.environ[RUNFILE_ENV_VAR])
     else:
-        python_args += ["-m", "fv3config.fv3run"]
+        python_args += ["-m", "fv3gfs.run"]
     return python_args
 
 

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -204,7 +204,7 @@ def test_get_runfile_args(runfile, expected_bind_mount_args, expected_python_arg
             "/path/to/runfile.py",
             ["python3", "-m", "mpi4py", "/path/to/runfile.py"],
         ),
-        (None, None, ["python3", "-m", "mpi4py", "-m", "fv3config.fv3run"]),
+        (None, None, ["python3", "-m", "mpi4py", "-m", "fv3gfs.run"]),
     ],
 )
 def test__get_native_python_args(monkeypatch, runfile, expected, env_var):


### PR DESCRIPTION
Instead of making the default flag to the python command in the mpi call be

    python -m mpi4py -m fv3gfs.run

I accidentally made it call

    python -m mpi4py -m fv3config.fv3run.

This has the effect of infinitely recursing into fv3config I think. I also used
the wrong main module name in the tests. I don't believe this effects any
workflows, since it hasn't been incorporated in the master fv3gfs-python image
yet. Both changes should be fixed now.