### PR TITLE
Add ability to use a custom field_table file

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -81,29 +81,22 @@ filesystem must be given as absolute paths. If paths are given that begin with `
 attempt to download the specified file or files from Google Cloud Storage. For this functionality, ``gcsfs``
 must be installed and authorized to download from the specified bucket.
 
-A ``field_table`` file is required for running the model, though it is not
-necessarily a required key in the ``config`` dictionary. In this file, names
-and properties of the different tracers used in the model are specified. If
-not provided in the ``config`` dictionary, ``fv3config`` will attempt to infer
-the required ``field_table`` based on the namelist parameters specified. This
-is typically recommended, because different ``field_table`` files are required
-depending on the model configuration, and it can be nice to rely on
-``fv3config`` to decide on what the appropriate file should be. That said, it
-can be useful to be able to override this. If one specifies a file path as a
-``field_table``, this file will be used regardless of the namelist
-parameters. If one specifies a directory as a ``field_table`` it will be
-assumed that the reference ``field_table`` files will be present in this
-directory, and will be used in place of the default reference ``field_table``
-files provided with ``fv3config``.  The current reference ``field_table`` files
-provided in ``fv3config`` correspond with files used for running with Zhao-Carr
-microphysics (``field_table_ZhaoCarr``) or with GFDL microphysics
-(``field_table_GFDLMP``). In FV3GFS these correspond with running with
-``gfs_phys_nml`` namelist parameters of ``imp_physics=99``, ``ncld=1``, and
-``imp_physics=11``, ``ncld=5``, respectively.
-
 The ``namelist`` item is special in that it is explicitly stored in the ``config`` dictionary. For the
 fv3gfs model, individual namelists are specified for various components of the model. As an example, the
 vertical resolution can be accessed via ``config['namelist']['fv_core_nml']['npz']``.
+
+By default, fv3config attempts to automatically select the ``field_table`` file
+to use for the model based on the selected microphysics scheme in the
+namelist. This supports Zhao-Carr or GFDL microphysics. If the user provides a
+``field_table`` key indicating a filename in the configuration dictionary, that
+file will be used instead.
+
+.. note::
+   The `Han and Bretherton (2019) <https://journals.ametsoc.org/doi/full/10.1175/WAF-D-18-0146.1>`_ TKE-EDMF
+   boundary layer scheme requires an additional tracer to be defined in the
+   ``field_table`` for TKE. This scheme is currently not supported by default
+   in ``fv3config``; however for the time being one can supply a custom
+   ``field_table`` for this purpose.
 
 Some helper functions exist for editing and retrieving information from configuration
 dictionaries, like :py:func:`fv3config.get_run_duration` and
@@ -266,3 +259,5 @@ restart initial conditions can be created with::
     config['initial_conditions'] = 'restart_example'
     config = enable_restart(config)
     write_run_directory(config, './rundir')
+
+.. _HB2019: https://journals.ametsoc.org/doi/full/10.1175/WAF-D-18-0146.1

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -81,6 +81,26 @@ filesystem must be given as absolute paths. If paths are given that begin with `
 attempt to download the specified file or files from Google Cloud Storage. For this functionality, ``gcsfs``
 must be installed and authorized to download from the specified bucket.
 
+A ``field_table`` file is required for running the model, though it is not
+necessarily a required key in the ``config`` dictionary. In this file, names
+and properties of the different tracers used in the model are specified. If
+not provided in the ``config`` dictionary, ``fv3config`` will attempt to infer
+the required ``field_table`` based on the namelist parameters specified. This
+is typically recommended, because different ``field_table`` files are required
+depending on the model configuration, and it can be nice to rely on
+``fv3config`` to decide on what the appropriate file should be. That said, it
+can be useful to be able to override this. If one specifies a file path as a
+``field_table``, this file will be used regardless of the namelist
+parameters. If one specifies a directory as a ``field_table`` it will be
+assumed that the reference ``field_table`` files will be present in this
+directory, and will be used in place of the default reference ``field_table``
+files provided with ``fv3config``.  The current reference ``field_table`` files
+provided in ``fv3config`` correspond with files used for running with Zhao-Carr
+microphysics (``field_table_ZhaoCarr``) or with GFDL microphysics
+(``field_table_GFDLMP``). In FV3GFS these correspond with running with
+``gfs_phys_nml`` namelist parameters of ``imp_physics=99``, ``ncld=1``, and
+``imp_physics=11``, ``ncld=5``, respectively.
+
 The ``namelist`` item is special in that it is explicitly stored in the ``config`` dictionary. For the
 fv3gfs model, individual namelists are specified for various components of the model. As an example, the
 vertical resolution can be accessed via ``config['namelist']['fv_core_nml']['npz']``.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -259,5 +259,3 @@ restart initial conditions can be created with::
     config['initial_conditions'] = 'restart_example'
     config = enable_restart(config)
     write_run_directory(config, './rundir')
-
-.. _HB2019: https://journals.ametsoc.org/doi/full/10.1175/WAF-D-18-0146.1

--- a/fv3config/_datastore.py
+++ b/fv3config/_datastore.py
@@ -235,7 +235,7 @@ def _infer_field_table_filename(config):
         raise NotImplementedError(
             f"Field table does not exist for {microphysics_name} microphysics"
         )
-    return os.path.join(filename)
+    return filename
 
 
 def get_diag_table_filename(config):

--- a/fv3config/_datastore.py
+++ b/fv3config/_datastore.py
@@ -222,7 +222,7 @@ def get_field_table_filename(config):
             )
         else:
             return get_external_field_table_filename(config, field_table)
-        
+
 
 def _infer_field_table_filename(config, field_table_directory):
     """Infer field_table filename given configuration dictionary

--- a/fv3config/_datastore.py
+++ b/fv3config/_datastore.py
@@ -179,7 +179,7 @@ def get_microphysics_name(config):
 
 
 def get_field_table_filename(config):
-    """Get field_table filename fiven configuration dictionary
+    """Get field_table filename given configuration dictionary
 
     Args:
         config (dict): a configuration dictionary
@@ -193,8 +193,10 @@ def get_field_table_filename(config):
     field_table = config.get("field_table", None)
     if field_table is None:
         field_table_dir = os.path.join(DATA_DIR, "field_table")
-    elif os.path.isabs(field_table):
-        if os.path.isfile(field_table):
+    elif filesystem.isabs(field_table) and filesystem.get_fs(field_table).exists(
+        field_table
+    ):
+        if filesystem.get_fs(field_table).isfile(field_table):
             return field_table
         else:
             field_table_dir = field_table
@@ -205,7 +207,7 @@ def get_field_table_filename(config):
         )
     inferred_filename = _infer_field_table_filename(config)
     field_table_filename = os.path.join(field_table_dir, inferred_filename)
-    if not os.path.isfile(field_table_filename):
+    if not filesystem.get_fs(field_table_filename).exists(field_table_filename):
         raise ConfigError(
             f"Inferred field_table file {field_table_filename} does not exist"
         )

--- a/fv3config/_datastore.py
+++ b/fv3config/_datastore.py
@@ -34,8 +34,8 @@ DIAG_TABLE_OPTIONS = {
     "grid_spec": os.path.join(DATA_DIR, "diag_table/diag_table_grid_spec"),
 }
 FIELD_TABLE_OPTIONS = {
-    "GFDLMP": os.path.join(DATA_DIR, "field_table/field_table_GFDLMP"),
-    "ZhaoCarr": os.path.join(DATA_DIR, "field_table/field_table_ZhaoCarr"),
+    "GFDLMP": "field_table_GFDLMP",
+    "ZhaoCarr": "field_table_ZhaoCarr",
 }
 
 
@@ -179,7 +179,44 @@ def get_microphysics_name(config):
 
 
 def get_field_table_filename(config):
-    """Get field_table filename given configuration dictionary
+    """Get field_table filename fiven configuration dictionary
+
+    Args:
+        config (dict): a configuration dictionary
+
+    Returns:
+        str: field_table filename
+
+    Raises:
+        ConfigError
+    """
+    field_table = config.get("field_table", None)
+    if field_table is None:
+        field_table_dir = os.path.join(DATA_DIR, "field_table")
+    elif os.path.isabs(field_table):
+        if os.path.isfile(field_table):
+            return field_table
+        else:
+            field_table_dir = field_table
+    else:
+        raise ConfigError(
+            f"field_table={field_table} must either be left unset or set "
+            "to an existing absolute path to a file or directory"
+        )
+    inferred_filename = _infer_field_table_filename(config)
+    field_table_filename = os.path.join(field_table_dir, inferred_filename)
+    if not os.path.isfile(field_table_filename):
+        raise ConfigError(
+            f"Inferred field_table file {field_table_filename} does not exist"
+        )
+    else:
+        return field_table_filename
+
+
+def _infer_field_table_filename(config):
+    """Infer field_table filename given configuration dictionary
+
+    The inference is made based on settings for the microphysics.
 
     Args:
         config (dict): a configuration dictionary
@@ -198,7 +235,7 @@ def get_field_table_filename(config):
         raise NotImplementedError(
             f"Field table does not exist for {microphysics_name} microphysics"
         )
-    return filename
+    return os.path.join(filename)
 
 
 def get_diag_table_filename(config):

--- a/fv3config/_datastore.py
+++ b/fv3config/_datastore.py
@@ -203,7 +203,6 @@ def get_field_table_filename(config):
     """
     field_table = config.get("field_table", DEFAULT_FIELD_TABLE_DIR)
     field_table_filename = _return_or_infer_field_table_filename(config, field_table)
-
     if not filesystem.is_existing_absolute_path(field_table_filename):
         raise ConfigError(
             f"field_table={field_table} must either be left unset or set "

--- a/fv3config/filesystem.py
+++ b/fv3config/filesystem.py
@@ -29,6 +29,11 @@ def isabs(path: str) -> bool:
         return os.path.isabs(path)
 
 
+def is_existing_absolute_path(path: str) -> bool:
+    """Return whether the path is an existing absolute path"""
+    return isabs(path) and get_fs(path).exists(path)
+
+
 def _get_protocol_prefix(location):
     """If a string starts with "<protocol>://"", return that part of the string.
     Otherwise, return an empty string.

--- a/tests/test_asset_list.py
+++ b/tests/test_asset_list.py
@@ -159,9 +159,15 @@ class AssetListTests(unittest.TestCase):
             )
             self.assertEqual(field_table_asset, expected_field_table_asset)
 
-    def test_get_field_table_asset_non_existent_filename_or_directory(self):
+    def test_get_field_table_asset_non_existent_relative_path(self):
         config = fv3config.get_default_config()
         config["field_table"] = "foo"
+        with self.assertRaises(fv3config.ConfigError):
+            get_field_table_asset(config)
+
+    def test_get_field_table_asset_non_existent_absolute_path(self):
+        config = fv3config.get_default_config()
+        config["field_table"] = "/foo"
         with self.assertRaises(fv3config.ConfigError):
             get_field_table_asset(config)
 

--- a/tests/test_asset_list.py
+++ b/tests/test_asset_list.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import shutil
+import tempfile
 import fv3config
 from fv3config._asset_list import (
     is_dict_or_list,
@@ -146,6 +147,42 @@ class AssetListTests(unittest.TestCase):
         config = fv3config.get_default_config()
         field_table_asset = get_field_table_asset(config)
         self.assertEqual(field_table_asset, DEFAULT_FIELD_TABLE_ASSET)
+
+    def test_get_field_table_asset_existing_filename(self):
+        config = fv3config.get_default_config()
+        with tempfile.NamedTemporaryFile() as field_table:
+            config["field_table"] = field_table.name
+            field_table_asset = get_field_table_asset(config)
+            directory, filename = os.path.split(field_table.name)
+            expected_field_table_asset = get_asset_dict(
+                directory, filename, target_name="field_table"
+            )
+            self.assertEqual(field_table_asset, expected_field_table_asset)
+
+    def test_get_field_table_asset_non_existent_filename_or_directory(self):
+        config = fv3config.get_default_config()
+        config["field_table"] = "foo"
+        with self.assertRaises(fv3config.ConfigError):
+            get_field_table_asset(config)
+
+    def test_get_field_table_asset_existing_directory(self):
+        config = fv3config.get_default_config()
+        with tempfile.TemporaryDirectory() as directory:
+            default_field_table_name = DEFAULT_FIELD_TABLE_ASSET["source_name"]
+            open(os.path.join(directory, default_field_table_name), "a").close()
+            config["field_table"] = directory
+            field_table_asset = get_field_table_asset(config)
+            expected_field_table_asset = get_asset_dict(
+                directory, default_field_table_name, target_name="field_table"
+            )
+            self.assertEqual(field_table_asset, expected_field_table_asset)
+
+    def test_get_field_table_asset_existing_directory_absent_file(self):
+        config = fv3config.get_default_config()
+        with tempfile.TemporaryDirectory() as directory:
+            config["field_table"] = directory
+            with self.assertRaises(fv3config.ConfigError):
+                get_field_table_asset(config)
 
     def test_ensure_is_list(self):
         sample_dict = {}


### PR DESCRIPTION
This adds the ability to add a custom field_table in the configuration dictionary to override the inferred version based on the microphysics scheme used.  The behavior is implemented as described in [this design document](https://paper.dropbox.com/doc/fv3config-supply-custom-field_table--At1mxQWSBpccxtSzp8aJXnOtAg-qnsdEpUuSPoimmslm1bPN) that @mcgibbon outlined earlier after a discussion with me and @oliverwm1.

I definitely see value in automatically setting the field_table used to prevent user-error as much as possible, so eventually I think we could look to somehow support the SHiELD use-case from that perspective; however, that introduces a few more complications that we'd have to think through:
- The microphysics scheme used is set with different namelist parameters than `imp_physics`.
- The new boundary layer scheme requires a new tracer for TKE, though one can still run with older PBL schemes, which do not require this additional tracer (so the field_table not only is dependent on the microphysics scheme, but also is dependent on the boundary layer scheme).

I don't think there's a particular downside to allowing users (at their own risk) to explicitly set the field_table used, so hopefully we're all on board for the spirit of this change!

Thanks @mcgibbon for pointing me to the `tempfile` module; that was quite useful for writing these tests.  