### PR TITLE
Feature/kube job label  (Necessary for workflow orchestration)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ ENV/
 
 # PyCharm
 .idea/
+
+# VSCode
+.vscode/

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -57,7 +57,7 @@ def run_kubernetes(
             kubernetes job. if set to "Always", will always pull the latest image.
             When "IfNotPresent", will only pull if no image has already been pulled.
             Defaults to "IfNotPresent".
-        job_labels (Mapping[str, str], optional): labels provided as key-value pairs 
+        job_labels (Mapping[str, str], optional): labels provided as key-value pairs
             to apply to job pod.  Useful for grouping jobs together in status checks.
     """
     job = _get_job(
@@ -213,7 +213,7 @@ class KubernetesConfig:
                 kubernetes job. if set to "Always", will always pull the latest image.
                 When "IfNotPresent", will only pull if no image has already been pulled.
                 Defaults to "IfNotPresent".
-            job_labels (Mapping[str, str], optional): labels provided as key-value pairs 
+            job_labels (Mapping[str, str], optional): labels provided as key-value pairs
                 to apply to job pod.  Useful for grouping jobs together in status checks.
         """
         if jobname is None:

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -174,7 +174,7 @@ def _container_to_job(container, kube_config):
     job = kube.client.V1Job(
         api_version="batch/v1",
         kind="Job",
-        metadata=kube.client.V1ObjectMeta(name=kube_config.jobname,),
+        metadata=kube.client.V1ObjectMeta(name=kube_config.jobname),
         spec=job_spec,
     )
     return job
@@ -223,7 +223,7 @@ class KubernetesConfig:
         self.gcp_secret = gcp_secret
         self.image_pull_policy = image_pull_policy
         if experiment_label is not None:
-            self.experiment_label = {"experiment_group": experiment_label}
+            self.experiment_label = {"experiment_group": str(experiment_label)}
         else:
             self.experiment_label = {}
 

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -23,7 +23,7 @@ def run_kubernetes(
     cpu_count=1,
     gcp_secret=None,
     image_pull_policy="IfNotPresent",
-    experiment_label=None
+    experiment_label=None,
 ):
     """Submit a kubernetes job to perform a fv3run operation.
 
@@ -91,7 +91,13 @@ def _get_job(
 ):
     _ensure_locations_are_remote(config_location, outdir)
     kube_config = KubernetesConfig(
-        jobname, memory_gb, memory_gb_limit, cpu_count, gcp_secret, image_pull_policy, experiment_label,
+        jobname,
+        memory_gb,
+        memory_gb_limit,
+        cpu_count,
+        gcp_secret,
+        image_pull_policy,
+        experiment_label,
     )
     return _create_job_object(
         config_location, outdir, docker_image, runfile, kube_config

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -64,8 +64,8 @@ def image_pull_policy(request):
     return request.param
 
 
-@pytest.fixture(params=["test_exp_group", None])
-def experiment_label(request):
+@pytest.fixture(params=[{"job_group": "this_group", "extra_group": "this_extra"}, None])
+def job_labels(request):
     return request.param
 
 
@@ -93,7 +93,7 @@ def test_get_job(
     cpu_count,
     gcp_secret,
     image_pull_policy,
-    experiment_label,
+    job_labels,
 ):
     job = fv3config.fv3run._kubernetes._get_job(
         config_location,
@@ -106,7 +106,7 @@ def test_get_job(
         cpu_count,
         gcp_secret,
         image_pull_policy,
-        experiment_label,
+        job_labels,
     )
     _check_job(job, jobname)
     job_spec = job.spec
@@ -124,7 +124,7 @@ def test_get_job(
     assert len(pod_spec.tolerations) == 1
     toleration = pod_spec.tolerations[0]
     _check_toleration(toleration)
-    _check_labels(job.spec.template.metadata, experiment_label)
+    _check_labels(job.spec.template.metadata, job_labels)
 
 
 def _check_secret(gcp_secret, container, pod_spec):
@@ -199,11 +199,12 @@ def _check_env(env_list, key, value_or_none):
         assert any(env.name == key and env.value == value_or_none for env in env_list)
 
 
-def _check_labels(metadata, exp_label):
-    if exp_label is not None:
-        assert "experiment_group" in metadata.labels
-        assert metadata.labels["experiment_group"] == exp_label
+def _check_labels(metadata, job_labels):
+    if job_labels is not None:
+        for key, value in job_labels.items():
+            assert key in metadata.labels
+            assert metadata.labels[key] == value
     else:
-        assert not hasattr(metadata.labels, "experiment_group")
+        assert len(metadata.labels) == 1
 
     assert metadata.labels["app"] == "fv3run"

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -63,6 +63,7 @@ def gcp_secret(request):
 def image_pull_policy(request):
     return request.param
 
+
 @pytest.fixture(params=["test_exp_group", None])
 def experiment_label(request):
     return request.param
@@ -124,7 +125,6 @@ def test_get_job(
     toleration = pod_spec.tolerations[0]
     _check_toleration(toleration)
     _check_labels(job.spec.template.metadata, experiment_label)
-
 
 
 def _check_secret(gcp_secret, container, pod_spec):
@@ -205,5 +205,5 @@ def _check_labels(metadata, exp_label):
         assert metadata.labels["experiment_group"] == exp_label
     else:
         assert not hasattr(metadata.labels, "experiment_group")
-    
+
     assert metadata.labels["app"] == "fv3run"


### PR DESCRIPTION
This small PR adds an option to provide an experiment label for the submitted Kubernetes job.  The label is used by `fv3net` to check for active jobs in the group while waiting for completion.