### PR TITLE
orographic_forcing can optionally be a cloud bucket

### DIFF
--- a/fv3config/_datastore.py
+++ b/fv3config/_datastore.py
@@ -20,6 +20,10 @@ FORCING_OPTIONS_DICT = {
     "default": "base_forcing",
 }
 
+OROGRAPHIC_FORCING_OPTIONS_DICT = {
+    "default": "orographic_data",
+}
+
 INITIAL_CONDITIONS_OPTIONS_DICT = {
     "gfs_example": "initial_conditions/gfs_initial_conditions",
     "restart_example": "initial_conditions/restart_initial_conditions",
@@ -45,11 +49,15 @@ def get_orographic_forcing_directory(config):
     specified by a config dictionary.
     """
     resolution = get_resolution(config)
-    dirname = os.path.join(get_internal_cache_dir(), f"orographic_data/{resolution}")
-    if not os.path.isdir(dirname):
-        valid_options = os.listdir(
-            os.path.join(get_internal_cache_dir(), "orographic_data")
-        )
+    if 'orographic_forcing' not in config:
+        orographic_forcing_spec = 'default'
+    else:
+        orographic_forcing_spec = config['orographic_forcing']
+    parent_dirname = resolve_option(orographic_forcing_spec, OROGRAPHIC_FORCING_OPTIONS_DICT)
+    dirname = os.path.join(parent_dirname, resolution)
+
+    if get_internal_cache_dir() in dirname and not os.path.isdir(dirname):
+        valid_options = os.listdir(parent_dirname)
         raise ConfigError(
             f"resolution {resolution} is unsupported; valid options are {valid_options}"
         )

--- a/fv3config/_datastore.py
+++ b/fv3config/_datastore.py
@@ -49,7 +49,9 @@ def get_orographic_forcing_directory(config):
     specified by a config dictionary.
     """
     resolution = get_resolution(config)
-    parent_dirname = resolve_option(config.get('orographic_forcing', 'default'), OROGRAPHIC_FORCING_OPTIONS_DICT)
+    parent_dirname = resolve_option(
+        config.get("orographic_forcing", "default"), OROGRAPHIC_FORCING_OPTIONS_DICT
+    )
     dirname = os.path.join(parent_dirname, resolution)
     fs = filesystem.get_fs(dirname)
     if not fs.isdir(dirname):

--- a/fv3config/_datastore.py
+++ b/fv3config/_datastore.py
@@ -49,15 +49,11 @@ def get_orographic_forcing_directory(config):
     specified by a config dictionary.
     """
     resolution = get_resolution(config)
-    if 'orographic_forcing' not in config:
-        orographic_forcing_spec = 'default'
-    else:
-        orographic_forcing_spec = config['orographic_forcing']
-    parent_dirname = resolve_option(orographic_forcing_spec, OROGRAPHIC_FORCING_OPTIONS_DICT)
+    parent_dirname = resolve_option(config.get('orographic_forcing', 'default'), OROGRAPHIC_FORCING_OPTIONS_DICT)
     dirname = os.path.join(parent_dirname, resolution)
-
-    if get_internal_cache_dir() in dirname and not os.path.isdir(dirname):
-        valid_options = os.listdir(parent_dirname)
+    fs = filesystem.get_fs(dirname)
+    if not fs.isdir(dirname):
+        valid_options = fs.listdir(parent_dirname)
         raise ConfigError(
             f"resolution {resolution} is unsupported; valid options are {valid_options}"
         )


### PR DESCRIPTION
Enable setting an 'orographic_forcing' in the configuration yaml that can be a cloud bucket, while if this key missing or set to default will use the local data cache as it did before.