### PR TITLE
Changes needed for the fv3net one-step jobs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+Current
+_______
+
+* Do not require output dir and fv3config to be remote in ``run_kubernetes``
+* Fix bug when submitting k8s jobs with images that have an "_" in them
 
 0.2.0 (2020-01-27)
 ------------------

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -2,7 +2,6 @@ import os
 import re
 import uuid
 from .._exceptions import DelayedImportError
-from .. import filesystem
 from ._docker import _get_python_command
 
 try:

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -89,7 +89,6 @@ def _get_job(
     image_pull_policy="IfNotPresent",
     job_labels=None,
 ):
-    # _ensure_locations_are_remote(config_location, outdir)
     kube_config = KubernetesConfig(
         jobname,
         memory_gb,
@@ -102,23 +101,6 @@ def _get_job(
     return _create_job_object(
         config_location, outdir, docker_image, runfile, kube_config
     )
-
-
-def _ensure_locations_are_remote(config_location, outdir):
-    for location, description in (
-        (config_location, "yaml configuration"),
-        (outdir, "output directory"),
-    ):
-        if location is not None:
-            _ensure_is_remote(location, description)
-
-
-def _ensure_is_remote(location, description):
-    if filesystem._is_local_path(location):
-        raise ValueError(
-            f"{description} must be a remote path when running on kubernetes, "
-            f"instead is {location}"
-        )
 
 
 def _submit_job(job, namespace):

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -1,6 +1,9 @@
 import os
 import re
 import uuid
+import warnings
+
+from .. import filesystem
 from .._exceptions import DelayedImportError
 from ._docker import _get_python_command
 
@@ -59,6 +62,12 @@ def run_kubernetes(
         job_labels (Mapping[str, str], optional): labels provided as key-value pairs
             to apply to job pod.  Useful for grouping jobs together in status checks.
     """
+    if filesystem._is_local_path(outdir):
+        warnings.warn(
+            f"Output directory {outdir} is a local path, so it will not be accesible "
+            "once the job finishes."
+        )
+
     job = _get_job(
         config_location,
         outdir,

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -93,7 +93,7 @@ def _get_job(
 ):
     if filesystem._is_local_path(outdir):
         warnings.warn(
-            f"Output directory {outdir} is a local path, so it will not be accesible "
+            f"Output directory {outdir} is a local path, so it will not be accessible "
             "once the job finishes."
         )
 

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -62,12 +62,6 @@ def run_kubernetes(
         job_labels (Mapping[str, str], optional): labels provided as key-value pairs
             to apply to job pod.  Useful for grouping jobs together in status checks.
     """
-    if filesystem._is_local_path(outdir):
-        warnings.warn(
-            f"Output directory {outdir} is a local path, so it will not be accesible "
-            "once the job finishes."
-        )
-
     job = _get_job(
         config_location,
         outdir,
@@ -97,6 +91,12 @@ def _get_job(
     image_pull_policy="IfNotPresent",
     job_labels=None,
 ):
+    if filesystem._is_local_path(outdir):
+        warnings.warn(
+            f"Output directory {outdir} is a local path, so it will not be accesible "
+            "once the job finishes."
+        )
+
     kube_config = KubernetesConfig(
         jobname,
         memory_gb,

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -89,7 +89,7 @@ def _get_job(
     image_pull_policy="IfNotPresent",
     job_labels=None,
 ):
-    _ensure_locations_are_remote(config_location, outdir)
+    # _ensure_locations_are_remote(config_location, outdir)
     kube_config = KubernetesConfig(
         jobname,
         memory_gb,
@@ -142,7 +142,7 @@ def _create_job_object(config_location, outdir, docker_image, runfile, kube_conf
 
 def _get_name_from_image(docker_image):
     name = os.path.basename(docker_image)
-    return re.split(r"\W+", name)[0]
+    return re.split(r"\W+", name)[0].replace("_", "-")
 
 
 def _get_kube_command(config_location, outdir, runfile=None):

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 import contextlib
 import resource
 import subprocess
@@ -20,7 +19,7 @@ RUNFILE_ENV_VAR = "FV3CONFIG_DEFAULT_RUNFILE"
 logger = logging.getLogger("fv3run")
 
 
-def run_native(config_dict_or_location, outdir, runfile=None, stderr=sys.stderr, stdout=sys.stdout):
+def run_native(config_dict_or_location, outdir, runfile=None):
     """Run the FV3GFS model with the given configuration.
 
     Copies the resulting directory to a target location. Will use the Google cloud
@@ -53,7 +52,7 @@ def run_native(config_dict_or_location, outdir, runfile=None, stderr=sys.stderr,
                 localdir,
                 n_processes,
                 runfile=runfile,
-                mpi_flags=_add_oversubscribe_if_necessary(MPI_FLAGS, n_processes)
+                mpi_flags=_add_oversubscribe_if_necessary(MPI_FLAGS, n_processes),
             )
 
 
@@ -130,6 +129,8 @@ def _run_experiment(dirname, n_processes, runfile, mpi_flags=None):
         subprocess.check_call(
             ["mpirun", "-n", str(n_processes)] + mpi_flags + python_command,
             cwd=dirname,
+            stdout=out_file,
+            stderr=err_file,
         )
 
 

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -130,8 +130,6 @@ def _run_experiment(dirname, n_processes, runfile, mpi_flags=None):
         subprocess.check_call(
             ["mpirun", "-n", str(n_processes)] + mpi_flags + python_command,
             cwd=dirname,
-            # stdout=out_file,
-            # stderr=err_file,
         )
 
 

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import contextlib
 import resource
 import subprocess
@@ -19,7 +20,7 @@ RUNFILE_ENV_VAR = "FV3CONFIG_DEFAULT_RUNFILE"
 logger = logging.getLogger("fv3run")
 
 
-def run_native(config_dict_or_location, outdir, runfile=None):
+def run_native(config_dict_or_location, outdir, runfile=None, stderr=sys.stderr, stdout=sys.stdout):
     """Run the FV3GFS model with the given configuration.
 
     Copies the resulting directory to a target location. Will use the Google cloud
@@ -52,7 +53,7 @@ def run_native(config_dict_or_location, outdir, runfile=None):
                 localdir,
                 n_processes,
                 runfile=runfile,
-                mpi_flags=_add_oversubscribe_if_necessary(MPI_FLAGS, n_processes),
+                mpi_flags=_add_oversubscribe_if_necessary(MPI_FLAGS, n_processes)
             )
 
 
@@ -129,8 +130,8 @@ def _run_experiment(dirname, n_processes, runfile, mpi_flags=None):
         subprocess.check_call(
             ["mpirun", "-n", str(n_processes)] + mpi_flags + python_command,
             cwd=dirname,
-            stdout=out_file,
-            stderr=err_file,
+            # stdout=out_file,
+            # stderr=err_file,
         )
 
 

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -69,20 +69,6 @@ def job_labels(request):
     return request.param
 
 
-def test_local_config_rejected(outdir, docker_image, runfile):
-    with pytest.raises(ValueError):
-        fv3config.fv3run._kubernetes._get_job(
-            "/local/dir/config.yml", outdir, docker_image, runfile
-        )
-
-
-def test_local_outdir_rejected(config_location, docker_image, runfile):
-    with pytest.raises(ValueError):
-        fv3config.fv3run._kubernetes._get_job(
-            config_location, "/local/outdir", docker_image, runfile
-        )
-
-
 def test_get_job(
     config_location,
     outdir,

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -12,9 +12,9 @@ def config_location():
     return "gs://my-bucket/fv3config.yml"
 
 
-@pytest.fixture
-def outdir():
-    return "gs://my-bucket/rundir"
+@pytest.fixture(params=["local", "remote"])
+def outdir(request):
+    return {"remote": "gs://my-bucket/rundir", "local": "/tmp/rundir"}[request.param]
 
 
 @pytest.fixture(params=["default", "tagged"])


### PR DESCRIPTION
The PR changes the behavior of `run_kubernetes` to not ensure that the locations of the fv3config.yml and the output directory are remote. This assumption is too stringent. run_k8s should be able to use fv3configs stored in the container's file system and save to arbitrary locations (including ones in the container's filesystems or k8s local volume that is mounted).

Also fix a bug when generating the container name for docker images with an "_" in them. K8s does not allow "_" in the name of container.