### PR TITLE
Pass arbitrary kwargs from run_docker/run_k8s to run_native

### DIFF
--- a/fv3config/fv3run/_docker.py
+++ b/fv3config/fv3run/_docker.py
@@ -54,7 +54,7 @@ def run_docker(
     outdir_in_docker = _get_outdir_args(docker_args, bind_mount_args, outdir)
     runfile_in_docker = _get_runfile_args(runfile, bind_mount_args)
 
-    python_command = run_native.command(config_dict, outdir_in_docker, runfile=runfile_in_docker)
+    python_command = run_native.command(config_dict, outdir_in_docker, runfile=runfile_in_docker, **kwargs)
 
     subprocess.check_call(
         DOCKER_COMMAND

--- a/fv3config/fv3run/_docker.py
+++ b/fv3config/fv3run/_docker.py
@@ -14,7 +14,7 @@ FV3RUN_MODULE = "fv3config.fv3run"
 
 
 def run_docker(
-    config_dict_or_location, outdir, docker_image, runfile=None, keyfile=None, **kwargs
+    config_dict_or_location, outdir, docker_image, runfile=None, keyfile=None
 ):
     """Run the FV3GFS model in a docker container with the given configuration.
 
@@ -52,7 +52,7 @@ def run_docker(
     runfile_in_docker = _get_runfile_args(runfile, bind_mount_args)
 
     python_command = run_native.command(
-        config_dict, DOCKER_OUTDIR, runfile=runfile_in_docker, **kwargs
+        config_dict, DOCKER_OUTDIR, runfile=runfile_in_docker
     )
 
     subprocess.check_call(

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -26,8 +26,7 @@ def run_kubernetes(
     gcp_secret=None,
     image_pull_policy="IfNotPresent",
     job_labels=None,
-    submit=True,
-    **kwargs,
+    submit=True
 ):
     """Submit a kubernetes job to perform a fv3run operation.
 
@@ -63,7 +62,6 @@ def run_kubernetes(
             Defaults to "IfNotPresent".
         job_labels (Mapping[str, str], optional): labels provided as key-value pairs
             to apply to job pod.  Useful for grouping jobs together in status checks.
-        **kwargs:  other arguments passed to be passed to run_native. These must be serializeable with json.
     """
 
     if filesystem._is_local_path(outdir):

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -26,7 +26,8 @@ def run_kubernetes(
     gcp_secret=None,
     image_pull_policy="IfNotPresent",
     job_labels=None,
-    **kwargs
+    submit=True,
+    **kwargs,
 ):
     """Submit a kubernetes job to perform a fv3run operation.
 
@@ -82,7 +83,10 @@ def run_kubernetes(
         image_pull_policy,
         job_labels,
     )
-    _submit_job(job, namespace)
+    if submit:
+        _submit_job(job, namespace)
+    else:
+        return job
 
 
 def _get_job(
@@ -131,15 +135,6 @@ def _create_job_object(command, docker_image, kube_config):
 def _get_name_from_image(docker_image):
     name = os.path.basename(docker_image)
     return re.split(r"\W+", name)[0].replace("_", "-")
-
-
-def _get_kube_command(config_location, outdir, runfile=None):
-    if runfile is None:
-        python_args = []
-    else:
-        python_args = ["--runfile", runfile]
-    python_command = _get_python_command(config_location, outdir)
-    return python_command + python_args
 
 
 def _container_to_job(container, kube_config):

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -26,7 +26,7 @@ def run_kubernetes(
     gcp_secret=None,
     image_pull_policy="IfNotPresent",
     job_labels=None,
-    submit=True
+    submit=True,
 ):
     """Submit a kubernetes job to perform a fv3run operation.
 
@@ -69,7 +69,7 @@ def run_kubernetes(
             f"Output directory {outdir} is a local path, so it will not be accessible "
             "once the job finishes."
         )
-    command = run_native.command(config_location, outdir, runfile=runfile, **kwargs)
+    command = run_native.command(config_location, outdir, runfile=runfile)
     job = _get_job(
         command,
         docker_image,

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -5,7 +5,7 @@ import warnings
 
 from .. import filesystem
 from .._exceptions import DelayedImportError
-from ._docker import _get_python_command
+from ._native import run_native
 
 try:
     import kubernetes as kube
@@ -26,6 +26,7 @@ def run_kubernetes(
     gcp_secret=None,
     image_pull_policy="IfNotPresent",
     job_labels=None,
+    **kwargs
 ):
     """Submit a kubernetes job to perform a fv3run operation.
 
@@ -61,12 +62,18 @@ def run_kubernetes(
             Defaults to "IfNotPresent".
         job_labels (Mapping[str, str], optional): labels provided as key-value pairs
             to apply to job pod.  Useful for grouping jobs together in status checks.
+        **kwargs:  other arguments passed to be passed to run_native. These must be serializeable with json.
     """
+
+    if filesystem._is_local_path(outdir):
+        warnings.warn(
+            f"Output directory {outdir} is a local path, so it will not be accessible "
+            "once the job finishes."
+        )
+    command = run_native.command(config_location, outdir, runfile=runfile, **kwargs)
     job = _get_job(
-        config_location,
-        outdir,
+        command,
         docker_image,
-        runfile,
         jobname,
         memory_gb,
         memory_gb_limit,
@@ -79,10 +86,8 @@ def run_kubernetes(
 
 
 def _get_job(
-    config_location,
-    outdir,
+    command,
     docker_image,
-    runfile=None,
     jobname=None,
     memory_gb=3.6,
     memory_gb_limit=None,
@@ -91,11 +96,6 @@ def _get_job(
     image_pull_policy="IfNotPresent",
     job_labels=None,
 ):
-    if filesystem._is_local_path(outdir):
-        warnings.warn(
-            f"Output directory {outdir} is a local path, so it will not be accessible "
-            "once the job finishes."
-        )
 
     kube_config = KubernetesConfig(
         jobname,
@@ -106,9 +106,7 @@ def _get_job(
         image_pull_policy,
         job_labels,
     )
-    return _create_job_object(
-        config_location, outdir, docker_image, runfile, kube_config
-    )
+    return _create_job_object(command, docker_image, kube_config)
 
 
 def _submit_job(job, namespace):
@@ -117,12 +115,12 @@ def _submit_job(job, namespace):
     api.create_namespaced_job(body=job, namespace=namespace)
 
 
-def _create_job_object(config_location, outdir, docker_image, runfile, kube_config):
+def _create_job_object(command, docker_image, kube_config):
     container = kube.client.V1Container(
         name=_get_name_from_image(docker_image),
         image=docker_image,
         image_pull_policy=kube_config.image_pull_policy,
-        command=_get_kube_command(config_location, outdir, runfile),
+        command=command,
         resources=kube_config.resource_requirements,
         volume_mounts=kube_config.volume_mounts,
         env=kube_config.env,

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -4,6 +4,7 @@ import contextlib
 import resource
 import functools
 import subprocess
+import inspect
 import multiprocessing
 import os
 import tempfile
@@ -24,6 +25,7 @@ logger = logging.getLogger("fv3run")
 
 def call_via_subprocess(func):
     this_module = func.__module__
+    signature = inspect.signature(func)
 
     def main(argv):
         import json
@@ -33,6 +35,10 @@ def call_via_subprocess(func):
 
     @functools.wraps(func)
     def command(*args, **kwargs) -> str:
+        # check that args and kwargs match func
+        # raises TypeError if not
+        signature.bind(*args, **kwargs)
+
         serialized = json.dumps([args, kwargs])
         return ["python", "-m", this_module, serialized]
 

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -28,8 +28,6 @@ def call_via_subprocess(func):
     signature = inspect.signature(func)
 
     def main(argv):
-        import json
-
         args, kwargs = json.loads(argv[1])
         func(*args, **kwargs)
 

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -2,7 +2,6 @@ import sys
 import logging
 import contextlib
 import resource
-import functools
 import subprocess
 import multiprocessing
 import os
@@ -25,10 +24,10 @@ logger = logging.getLogger("fv3run")
 def call_via_subprocess(func):
     this_module = func.__module__
 
-    def main():
+    def main(argv):
         import json
-        serialized = sys.argv[1]
-        args, kwargs = json.loads(serialized)
+
+        args, kwargs = json.loads(argv[1])
         func(*args, **kwargs)
 
     def command(*args, **kwargs) -> str:
@@ -41,7 +40,9 @@ def call_via_subprocess(func):
 
 
 @call_via_subprocess
-def run_native(config_dict_or_location, outdir, runfile=None, capture_output: bool = True):
+def run_native(
+    config_dict_or_location, outdir, runfile=None, capture_output: bool = True
+):
     """Run the FV3GFS model with the given configuration.
 
     Copies the resulting directory to a target location. Will use the Google cloud
@@ -175,4 +176,4 @@ def _copy_and_load_config_dict(config_location, local_target_location):
 
 
 if __name__ == "__main__":
-    run_native.main()
+    run_native.main(sys.arv)

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -55,7 +55,6 @@ def run_native(config_dict_or_location, outdir, runfile=None, capture_output: bo
         outdir (str): location to copy the resulting run directory
         runfile (str, optional): Python model script to use in place of the default.
     """
-    print(config_dict_or_location)
     _set_stacksize_unlimited()
     with _temporary_directory(outdir) as localdir:
         config_out_filename = os.path.join(localdir, CONFIG_OUT_FILENAME)

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -2,6 +2,7 @@ import sys
 import logging
 import contextlib
 import resource
+import functools
 import subprocess
 import multiprocessing
 import os
@@ -30,6 +31,7 @@ def call_via_subprocess(func):
         args, kwargs = json.loads(argv[1])
         func(*args, **kwargs)
 
+    @functools.wraps(func)
     def command(*args, **kwargs) -> str:
         serialized = json.dumps([args, kwargs])
         return ["python", "-m", this_module, serialized]
@@ -176,4 +178,4 @@ def _copy_and_load_config_dict(config_location, local_target_location):
 
 
 if __name__ == "__main__":
-    run_native.main(sys.arv)
+    run_native.main(sys.argv)

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -1,12 +1,15 @@
+import sys
 import logging
 import contextlib
 import resource
+import functools
 import subprocess
 import multiprocessing
 import os
 import tempfile
 import warnings
 import yaml
+import json
 from ..config import write_run_directory, get_n_processes, config_to_yaml
 from .. import filesystem
 

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -231,12 +231,9 @@ def maybe_get_file(*args, **kwargs):
 def test_get_docker_args(outdir, expected_docker_args, expected_bind_mount_args):
     docker_args = []
     bind_mount_args = []
-    outdir_in_docker = fv3config.fv3run._docker._get_docker_args(
-        docker_args, bind_mount_args, outdir
-    )
+    fv3config.fv3run._docker._get_docker_args(docker_args, bind_mount_args, outdir)
     assert docker_args == expected_docker_args
     assert bind_mount_args == expected_bind_mount_args
-    assert outdir_in_docker == "/outdir"
 
 
 @pytest.mark.parametrize(
@@ -453,3 +450,13 @@ def test_call_via_subprocess_main():
 
     # assert results where the same
     assert dummy_ans == python_ans
+
+
+@pytest.mark.xfail()
+def test_call_via_subprocess_command_fails_with_bad_args():
+    @call_via_subprocess
+    def dummy_function(a, b):
+        pass
+
+    with pytest.raises(ValueError):
+        dummy_function.command(1, 2, 3, king="kong")

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -417,7 +417,7 @@ def test_call_via_subprocess_command():
     import json
 
     @call_via_subprocess
-    def dummy_function(*obj):
+    def dummy_function(*obj, **kwargs):
         pass
 
     command = dummy_function.command(1, a=1, b=1)
@@ -452,11 +452,10 @@ def test_call_via_subprocess_main():
     assert dummy_ans == python_ans
 
 
-@pytest.mark.xfail()
 def test_call_via_subprocess_command_fails_with_bad_args():
     @call_via_subprocess
     def dummy_function(a, b):
         pass
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         dummy_function.command(1, 2, 3, king="kong")

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -10,7 +10,11 @@ import pytest
 import yaml
 import gcsfs
 import fv3config
-from fv3config.fv3run._native import _get_python_command, RUNFILE_ENV_VAR
+from fv3config.fv3run._native import (
+    _get_python_command,
+    RUNFILE_ENV_VAR,
+    call_via_subprocess,
+)
 
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 MOCK_RUNSCRIPT = os.path.abspath(os.path.join(TEST_DIR, "testdata/mock_runscript.py"))
@@ -169,29 +173,19 @@ def test_fv3run_with_mpi(runner):
 @pytest.mark.parametrize(
     "runfile, expected_bind_mount_args, expected_python_args",
     [
-        [
-            "/tmp/runfile.py",
-            ["-v", "/tmp/runfile.py:/runfile.py"],
-            ["--runfile", "/runfile.py"],
-        ],
+        ["/tmp/runfile.py", ["-v", "/tmp/runfile.py:/runfile.py"], "/runfile.py"],
         [
             "relative.py",
             ["-v", f"{os.path.join(os.getcwd(), 'relative.py')}:/runfile.py"],
-            ["--runfile", "/runfile.py"],
+            "/runfile.py",
         ],
-        [
-            "gs://bucket-name/runfile.py",
-            [],
-            ["--runfile", "gs://bucket-name/runfile.py"],
-        ],
+        ["gs://bucket-name/runfile.py", [], "gs://bucket-name/runfile.py"],
     ],
 )
 def test_get_runfile_args(runfile, expected_bind_mount_args, expected_python_args):
     bind_mount_args = []
-    python_args = []
-    fv3config.fv3run._docker._get_runfile_args(runfile, bind_mount_args, python_args)
+    runfile = fv3config.fv3run._docker._get_runfile_args(runfile, bind_mount_args)
     assert bind_mount_args == expected_bind_mount_args
-    assert python_args == expected_python_args
 
 
 @pytest.mark.parametrize(
@@ -224,43 +218,6 @@ def maybe_get_file(*args, **kwargs):
 
 
 @pytest.mark.parametrize(
-    "config, tempfile, expected_config_location, expected_bind_mount_args",
-    [
-        [
-            fv3config.get_default_config(),
-            MockTempfile(name="/tmp/file"),
-            fv3config.fv3run._docker.DOCKER_CONFIG_LOCATION,
-            ["-v", "/tmp/file:/fv3config.yml"],
-        ],
-        [
-            "/absolute/path/fv3config.yml",
-            MockTempfile(name="/tmp/file"),
-            fv3config.fv3run._docker.DOCKER_CONFIG_LOCATION,
-            ["-v", "/absolute/path/fv3config.yml:/fv3config.yml"],
-        ],
-        [
-            "gs://bucket-name/fv3config.yml",
-            MockTempfile(name="/tmp/file"),
-            "gs://bucket-name/fv3config.yml",
-            [],
-        ],
-    ],
-)
-def test_get_config_args(
-    config, tempfile, expected_config_location, expected_bind_mount_args
-):
-    # paths don't actually exist, but that doesn't matter for this test
-    # use mock to ignore the "not found" errors
-    with unittest.mock.patch("fv3config.filesystem.get_file", new=maybe_get_file):
-        bind_mount_args = []
-        config_location = fv3config.fv3run._docker._get_config_args(
-            config, tempfile, bind_mount_args
-        )
-        assert config_location == expected_config_location
-        assert bind_mount_args == expected_bind_mount_args
-
-
-@pytest.mark.parametrize(
     "outdir, expected_docker_args, expected_bind_mount_args",
     [
         [
@@ -274,9 +231,12 @@ def test_get_config_args(
 def test_get_docker_args(outdir, expected_docker_args, expected_bind_mount_args):
     docker_args = []
     bind_mount_args = []
-    fv3config.fv3run._docker._get_docker_args(docker_args, bind_mount_args, outdir)
+    outdir_in_docker = fv3config.fv3run._docker._get_docker_args(
+        docker_args, bind_mount_args, outdir
+    )
     assert docker_args == expected_docker_args
     assert bind_mount_args == expected_bind_mount_args
+    assert outdir_in_docker == "/outdir"
 
 
 @pytest.mark.parametrize(
@@ -454,3 +414,42 @@ def test_get_credentials_args(keyfile, expected_docker_args, expected_bind_mount
 def test_get_local_paths(config_dict, local_paths):
     return_value = fv3config.fv3run._docker._get_local_data_paths(config_dict)
     assert set(return_value) == set(local_paths)  # order does not matter
+
+
+def test_call_via_subprocess_command():
+    import json
+
+    @call_via_subprocess
+    def dummy_function(*obj):
+        pass
+
+    command = dummy_function.command(1, a=1, b=1)
+    args = command.pop()
+    assert json.loads(args) == [[1], dict(a=1, b=1)]
+    assert command == ["python", "-m", dummy_function.__module__]
+
+
+def test_call_via_subprocess_main():
+
+    # need to append outputs here since call_via_subprocess does not
+    # support return arguments
+    output = []
+
+    @call_via_subprocess
+    def dummy_function(*obj):
+        output.append(hash(obj))
+
+    inputs = (1, 2, 3)
+
+    # first call is via "main"
+    serialized_args = dummy_function.command(*inputs)[-1]
+    argv = [None, serialized_args]
+    dummy_function.main(argv)
+    dummy_ans = output.pop()
+
+    # second call is normal python call
+    dummy_function(*inputs)
+    python_ans = output.pop()
+
+    # assert results where the same
+    assert dummy_ans == python_ans


### PR DESCRIPTION
Changing the signature of run_native (e.g. to add an option changing the logging behavior), requires editing 3 other files: `run_kubernetes`, `run_docker`, and the `__main__.py`. This PR allows `run_kubernetes` and `run_docker` to pass arbitrary arguments to `run_native` provided that they are serializable with `json`. A side effect is that `run_kubernetes` can now take an actual configuration dictionary rather than a url pointing to one. 

It also tidies up the implementation of `run_kubernetes` especially. `run_docker` still has some unavoidable logic to do with creating the bind-mounts, but is slightly cleaner now too.