### PR TITLE
Allow enabling and disabling caching

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -58,6 +58,10 @@ a "fv3config-cache" subdirectory with unrelated files, or the cache files will n
 download until you call :py:func:`fv3config.refresh_downloaded_data` (which will delete any files
 in the subdirectory).
 
+Automatic caching of remote files can be disabled using the
+:py:func:`fv3config.do_remote_caching` routine.
+
+
 Configuration
 -------------
 

--- a/fv3config/__init__.py
+++ b/fv3config/__init__.py
@@ -13,9 +13,9 @@ from .config import (
 )
 from ._exceptions import InvalidFileError, ConfigError
 from ._datastore import ensure_data_is_downloaded
-from fv3config.cache_location import set_cache_dir, get_cache_dir
 from .fv3run import run_docker, run_native, run_kubernetes
 from ._asset_list import get_asset_dict
+from .caching import CACHE_REMOTE_FILES, do_remote_caching, set_cache_dir, get_cache_dir
 
 
 __author__ = """Vulcan Technologies LLC"""

--- a/fv3config/_asset_list.py
+++ b/fv3config/_asset_list.py
@@ -172,7 +172,7 @@ def write_asset(asset, target_directory):
     if not os.path.exists(os.path.dirname(target_path)):
         os.makedirs(os.path.dirname(target_path))
     if copy_method == "copy":
-        filesystem.get_file(source_path, target_path, cache=True)
+        filesystem.get_file(source_path, target_path)
     elif copy_method == "link":
         link_file(source_path, target_path)
     else:

--- a/fv3config/_datastore.py
+++ b/fv3config/_datastore.py
@@ -5,9 +5,9 @@ import logging
 import tempfile
 import requests
 
-from fv3config.cache_location import get_internal_cache_dir
-from fv3config.config.derive import get_resolution
-from fv3config.data import DATA_DIR
+from .caching import get_internal_cache_dir
+from .config.derive import get_resolution
+from .data import DATA_DIR
 from ._exceptions import ConfigError, DataMissingError
 from . import filesystem
 

--- a/fv3config/caching.py
+++ b/fv3config/caching.py
@@ -8,6 +8,15 @@ else:
     os.makedirs(USER_CACHE_DIR, exist_ok=True)
 CACHE_PREFIX = "fv3config-cache"
 
+CACHE_REMOTE_FILES = True
+
+
+def do_remote_caching(flag: bool):
+    if not isinstance(flag, bool):
+        raise TypeError(f"flag must be a boolean, was given {flag}")
+    global CACHE_REMOTE_FILES
+    CACHE_REMOTE_FILES = flag
+
 
 def set_cache_dir(parent_dirname):
     if not os.path.isdir(parent_dirname):

--- a/fv3config/caching.py
+++ b/fv3config/caching.py
@@ -12,6 +12,8 @@ CACHE_REMOTE_FILES = True
 
 
 def do_remote_caching(flag: bool):
+    """Set whether to cache remote files when accessed. Default is True.
+    """
     if not isinstance(flag, bool):
         raise TypeError(f"flag must be a boolean, was given {flag}")
     global CACHE_REMOTE_FILES

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,6 +3,7 @@ import tempfile
 import pytest
 import fv3config
 import os
+import shutil
 
 
 @pytest.mark.parametrize(
@@ -13,7 +14,7 @@ import os
     ],
 )
 def test_cache_filename(source_filename, cache_subpath):
-    cache_dir = fv3config.filesystem.get_internal_cache_dir()
+    cache_dir = fv3config.caching.get_internal_cache_dir()
     cache_filename = os.path.join(cache_dir, cache_subpath)
     result = fv3config.filesystem._get_cache_filename(source_filename)
     assert result == cache_filename
@@ -25,31 +26,71 @@ def test_cache_filename_raises_on_no_filename():
 
 
 class CacheDirectoryTests(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         cls.cache_dir = tempfile.TemporaryDirectory()
-        cls.original_cache_dir = fv3config.cache_location.get_cache_dir()
-        fv3config.cache_location.set_cache_dir(cls.cache_dir.name)
+        cls.original_cache_dir = fv3config.caching.get_cache_dir()
+        fv3config.caching.set_cache_dir(cls.cache_dir.name)
         fv3config.ensure_data_is_downloaded()
 
     @classmethod
     def tearDownClass(cls):
-        fv3config.cache_location.set_cache_dir(cls.original_cache_dir)
+        fv3config.caching.set_cache_dir(cls.original_cache_dir)
         cls.cache_dir.cleanup()
+
+    def tearDown(self):
+        gs_cache_dir = os.path.join(
+            self.cache_dir.name,
+            "fv3config-cache/gs/"
+        )
+        if os.path.isdir(gs_cache_dir):
+            shutil.rmtree(gs_cache_dir)
 
     def test_cache_diag_table(self):
         config = fv3config.get_default_config()
         config[
             "diag_table"
         ] = "gs://vcm-fv3config/config/diag_table/default/v1.0/diag_table"
+        cache_filename = os.path.join(
+            fv3config.get_cache_dir(),
+            "fv3config-cache/gs/vcm-fv3config/config/diag_table/default/v1.0/diag_table",
+        )
+        assert not os.path.isfile(cache_filename)
         with tempfile.TemporaryDirectory() as rundir:
             fv3config.write_run_directory(config, rundir)
-        assert os.path.isfile(
-            os.path.join(
-                fv3config.get_cache_dir(),
-                "fv3config-cache/gs/vcm-fv3config/config/diag_table/default/v1.0/diag_table",
-            )
+        assert os.path.isfile(cache_filename)
+
+    def test_disable_caching(self):
+        config = fv3config.get_default_config()
+        config[
+            "diag_table"
+        ] = "gs://vcm-fv3config/config/diag_table/default/v1.0/diag_table"
+        cache_filename = os.path.join(
+            fv3config.get_cache_dir(),
+            "fv3config-cache/gs/vcm-fv3config/config/diag_table/default/v1.0/diag_table",
         )
+        assert not os.path.isfile(cache_filename)
+        fv3config.do_remote_caching(False)
+        with tempfile.TemporaryDirectory() as rundir:
+            fv3config.write_run_directory(config, rundir)
+        assert not os.path.isfile(cache_filename)
+
+    def test_reenable_caching(self):
+        config = fv3config.get_default_config()
+        config[
+            "diag_table"
+        ] = "gs://vcm-fv3config/config/diag_table/default/v1.0/diag_table"
+        cache_filename = os.path.join(
+            fv3config.get_cache_dir(),
+            "fv3config-cache/gs/vcm-fv3config/config/diag_table/default/v1.0/diag_table",
+        )
+        assert not os.path.isfile(cache_filename)
+        fv3config.do_remote_caching(False)
+        fv3config.do_remote_caching(True)
+        with tempfile.TemporaryDirectory() as rundir:
+            fv3config.write_run_directory(config, rundir)
+        assert os.path.isfile(cache_filename)
 
     def test_cached_diag_table_is_not_redownloaded(self):
         config = fv3config.get_default_config()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -26,7 +26,6 @@ def test_cache_filename_raises_on_no_filename():
 
 
 class CacheDirectoryTests(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.cache_dir = tempfile.TemporaryDirectory()
@@ -40,10 +39,7 @@ class CacheDirectoryTests(unittest.TestCase):
         cls.cache_dir.cleanup()
 
     def tearDown(self):
-        gs_cache_dir = os.path.join(
-            self.cache_dir.name,
-            "fv3config-cache/gs/"
-        )
+        gs_cache_dir = os.path.join(self.cache_dir.name, "fv3config-cache/gs/")
         if os.path.isdir(gs_cache_dir):
             shutil.rmtree(gs_cache_dir)
 

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -4,7 +4,7 @@ import tempfile
 import fv3config
 import os
 
-import fv3config.cache_location
+import fv3config.caching
 
 TEST_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 TAR_GZ_FILENAME = os.path.join(
@@ -33,35 +33,35 @@ FILE_CONTENT = "mock_content\n"
 
 class DatastoreTests(unittest.TestCase):
     def test_get_archive_dir(self):
-        result = fv3config.cache_location.get_cache_dir()
+        result = fv3config.caching.get_cache_dir()
         assert isinstance(result, str)
         assert os.path.isabs(result)
 
     def test_set_then_get_archive_dir(self):
         with tempfile.TemporaryDirectory() as tempdir:
-            original = fv3config.cache_location.get_cache_dir()
+            original = fv3config.caching.get_cache_dir()
             try:
-                fv3config.cache_location.set_cache_dir(tempdir)
-                new = fv3config.cache_location.get_cache_dir()
+                fv3config.caching.set_cache_dir(tempdir)
+                new = fv3config.caching.get_cache_dir()
                 assert new != original
                 assert new == tempdir
             finally:
-                fv3config.cache_location.set_cache_dir(original)
+                fv3config.caching.set_cache_dir(original)
 
 
 class DatastoreFileTests(unittest.TestCase):
     def setUp(self):
         self._original_get = requests.get
         requests.get = mock_requests_get
-        self.original_cachedir = fv3config.cache_location.get_cache_dir()
+        self.original_cachedir = fv3config.caching.get_cache_dir()
         self._cachedir_obj = tempfile.TemporaryDirectory()
-        fv3config.cache_location.set_cache_dir(self._cachedir_obj.name)
+        fv3config.caching.set_cache_dir(self._cachedir_obj.name)
         self.cachedir = os.path.join(self._cachedir_obj.name, "fv3config-cache")
         MockResponse.times_called = 0
 
     def tearDown(self):
         requests.get = self._original_get
-        fv3config.cache_location.set_cache_dir(self.original_cachedir)
+        fv3config.caching.set_cache_dir(self.original_cachedir)
         self._cachedir_obj.cleanup()
 
     def test_ensure_data_is_downloaded_when_empty(self):

--- a/tests/test_forcingdata.py
+++ b/tests/test_forcingdata.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import tempfile
 import fv3config
-import fv3config.cache_location
+import fv3config.caching
 from fv3config._datastore import (
     get_base_forcing_directory,
     get_orographic_forcing_directory,
@@ -117,13 +117,13 @@ class ForcingTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.cache_dir = tempfile.TemporaryDirectory()
-        cls.original_cache_dir = fv3config.cache_location.get_cache_dir()
-        fv3config.cache_location.set_cache_dir(cls.cache_dir.name)
+        cls.original_cache_dir = fv3config.caching.get_cache_dir()
+        fv3config.caching.set_cache_dir(cls.cache_dir.name)
         fv3config.ensure_data_is_downloaded()
 
     @classmethod
     def tearDownClass(cls):
-        fv3config.cache_location.set_cache_dir(cls.original_cache_dir)
+        fv3config.caching.set_cache_dir(cls.original_cache_dir)
         cls.cache_dir.cleanup()
 
     def setUp(self):


### PR DESCRIPTION
Major changes:
- Adds a routine `fv3config.do_remote_caching` which sets the default caching behavior for remote files.

Minor changes:
- Renamed the `cache_location` module to `caching`.