### PR TITLE
Add --kubernetes flag and run model in outdir when outdir is local

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,27 +5,32 @@ History
 latest
 ------
 
+Major changes:
+~~~~~~~~~~~~~
+- Added `--kubernetes` command-line flag to output a kubernetes config yaml to stdout
+
 Minor changes:
 ~~~~~~~~~~~~~
-* Added the flag ``--mca btl_vader_single_copy_mechanism none to mpirun in fv3run`` to mpirun in fv3run
-* Add ReadTheDocs configuration file
-* Do not require output dir and fv3config to be remote in ``run_kubernetes``
-* Fix bug when submitting k8s jobs with images that have an "_" in them
+- Added the flag ``--mca btl_vader_single_copy_mechanism none to mpirun in fv3run`` to mpirun in fv3run
+- Add ReadTheDocs configuration file
+- Do not require output dir and fv3config to be remote in ``run_kubernetes``
+- Fix bug when submitting k8s jobs with images that have an "_" in them
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
-* Refactored run_kubernetes and run_docker to call run_native via a new API serializing
+- Refactored run_kubernetes and run_docker to call run_native via a new API serializing
   their args/kwargs as json strings. The
   fv3config version in a docker image must be greater than or equal inside a
   container to outside, or a silent error will occur.
+- When output location is set to a local path, the job now runs in that output location instead of in a temporary directory which then gets copied. This is done both to reduce copying time for large jobs, and to improve visibility of model behavior while running.
 
 0.2.0 (2020-01-27)
 ------------------
 
-* Began tagging version commits
+- Began tagging version commits
 
 
 0.1.0 (2019-10-11)
 ------------------
 
-* Initial pre-alpha release
+- Initial pre-alpha release

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -169,7 +169,9 @@ a yaml file. There is also a bash interface for running from yaml configuration.
 
     positional arguments:
       config                location of fv3config yaml file
-      outdir                location to copy final run directory
+      outdir                location to copy final run directory, used as run
+                            directory if local
+
 
     optional arguments:
       -h, --help            show this help message and exit
@@ -179,6 +181,9 @@ a yaml file. There is also a bash interface for running from yaml configuration.
                             given name
       --keyfile KEYFILE     google cloud storage key to use for cloud copy
                             commands
+      --kubernetes          if given, ignore --keyfile and output a yaml
+                            kubernetes config to stdout instead of submitting a
+                            run
 
 The only required inputs are ``config``, which specifies a yaml file containing the
 ``fv3config`` run directory configuration, and a final location to copy the run directory.
@@ -245,6 +250,19 @@ based on the default configuration dictionary::
 The gcp key is generally necessary to gain permissions to read and write from google
 cloud storage buckets. In the unlikely case that you are writing to a public bucket,
 it can be ommitted.
+
+From the command line, fv3run can be used to create a yaml file to submit for a
+kubernetes job. To create the file, add the ``--kubernetes`` flag to ``fv3run`` and
+pipe the result to a file. For example:
+
+  $ fv3run gs://bucket/config.yml gs://bucket/outdir --dockerimage us.gcr.io/vcm-ml/fv3gfs-python:latest --kubernetes > kubeconfig.yml
+
+The resulting file can be submitted using
+
+  $ kubectl apply -f kubeconfig.yml
+
+You can also modify the yaml file before submitting the job, for example to request more
+than one processor or a different amount of memory.
 
 Restart runs
 ------------

--- a/fv3config/_asset_list.py
+++ b/fv3config/_asset_list.py
@@ -130,7 +130,7 @@ def asset_list_from_path(from_location, target_location="", copy_method="copy"):
     Returns:
         list: a list of asset dictionaries
         """
-    if not filesystem._is_local_path(from_location):
+    if not filesystem.is_local_path(from_location):
         copy_method = "copy"
     asset_list = []
     for dirname, basename, relative_target_location in _asset_walk(from_location):
@@ -227,7 +227,7 @@ def config_to_asset_list(config):
 
 
 def link_file(source_item, target_item):
-    if any(not filesystem._is_local_path(item) for item in [source_item, target_item]):
+    if any(not filesystem.is_local_path(item) for item in [source_item, target_item]):
         raise NotImplementedError(
             "cannot perform linking operation involving remote urls "
             f"from {source_item} to {target_item}"

--- a/fv3config/filesystem.py
+++ b/fv3config/filesystem.py
@@ -56,7 +56,8 @@ def _get_path(location):
         return location
 
 
-def _is_local_path(location):
+def is_local_path(location):
+    """returns True if the location is local, False otherwise"""
     return _get_protocol_prefix(location) == ""
 
 
@@ -91,7 +92,7 @@ def get_file(source_filename: str, dest_filename: str, cache: bool = None):
     """
     if cache is None:
         cache = caching.CACHE_REMOTE_FILES
-    if not cache or _is_local_path(source_filename):
+    if not cache or is_local_path(source_filename):
         _get_file_uncached(source_filename, dest_filename)
     else:
         _get_file_cached(source_filename, dest_filename)
@@ -103,7 +104,7 @@ def _get_file_uncached(source_filename, dest_filename):
 
 
 def _get_file_cached(source_filename, dest_filename):
-    if _is_local_path(source_filename):
+    if is_local_path(source_filename):
         raise ValueError(f"will not cache a local path, was given {source_filename}")
     else:
         cache_location = _get_cache_filename(source_filename)

--- a/fv3config/fv3run/__main__.py
+++ b/fv3config/fv3run/__main__.py
@@ -22,8 +22,10 @@ Will use google cloud storage key at $GOOGLE_APPLICATION_CREDENTIALS by default.
         "config", type=str, action="store", help="location of fv3config yaml file"
     )
     parser.add_argument(
-        "outdir", type=str, action="store",
-        help="location to copy final run directory, used as run directory if local"
+        "outdir",
+        type=str,
+        action="store",
+        help="location to copy final run directory, used as run directory if local",
     )
     parser.add_argument(
         "--runfile",
@@ -100,8 +102,11 @@ def run(
     if docker_image is not None:
         if kubernetes:
             job = run_kubernetes(
-                config_dict_or_location, outdir, docker_image, runfile=runfile,
-                submit=False
+                config_dict_or_location,
+                outdir,
+                docker_image,
+                runfile=runfile,
+                submit=False,
             )
             yaml.dump(job.to_dict(), stream=sys.stdout)
         else:

--- a/fv3config/fv3run/__main__.py
+++ b/fv3config/fv3run/__main__.py
@@ -56,10 +56,24 @@ def main():
     Copies the resulting run directory to a target location.
     """
     args = _parse_args()
-    run(args.config, args.outdir, args.runfile, args.dockerimage, args.keyfile, args.kubernetes)
+    run(
+        args.config,
+        args.outdir,
+        args.runfile,
+        args.dockerimage,
+        args.keyfile,
+        args.kubernetes,
+    )
 
 
-def run(config_dict_or_location, outdir, runfile=None, docker_image=None, keyfile=None, kubernetes=False):
+def run(
+    config_dict_or_location,
+    outdir,
+    runfile=None,
+    docker_image=None,
+    keyfile=None,
+    kubernetes=False,
+):
     """Run the FV3GFS model with the given configuration.
 
     Copies the resulting directory to a target location. Will use the Google cloud
@@ -81,10 +95,7 @@ def run(config_dict_or_location, outdir, runfile=None, docker_image=None, keyfil
     if docker_image is not None:
         if kubernetes:
             run_kubernetes(
-                config_dict_or_location,
-                outdir,
-                docker_image,
-                runfile=runfile,
+                config_dict_or_location, outdir, docker_image, runfile=runfile,
             )
         else:
             run_docker(

--- a/fv3config/fv3run/_docker.py
+++ b/fv3config/fv3run/_docker.py
@@ -67,7 +67,7 @@ def _load_yaml(url):
 
 def _get_runfile_args(runfile, bind_mount_args) -> str:
     if runfile is not None:
-        if filesystem._is_local_path(runfile):
+        if filesystem.is_local_path(runfile):
             bind_mount_args += ["-v", f"{os.path.abspath(runfile)}:{DOCKER_RUNFILE}"]
             return DOCKER_RUNFILE
         else:
@@ -94,7 +94,7 @@ def _is_local_path(maybe_path_or_object):
     return (
         isinstance(maybe_path_or_object, str)
         and os.path.isabs(maybe_path_or_object)
-        and filesystem._is_local_path(maybe_path_or_object)
+        and filesystem.is_local_path(maybe_path_or_object)
     )
 
 
@@ -106,13 +106,13 @@ def _get_local_data_paths(config_dict):
             local_paths.append(potential_path)
         elif isinstance(potential_path, list):
             for asset in potential_path:
-                if filesystem._is_local_path(asset["source_location"]):
+                if filesystem.is_local_path(asset["source_location"]):
                     local_paths.append(
                         os.path.join(asset["source_location"], asset["source_name"])
                     )
         elif isinstance(potential_path, dict):
             asset = potential_path
-            if filesystem._is_local_path(asset["source_location"]):
+            if filesystem.is_local_path(asset["source_location"]):
                 local_paths.append(
                     os.path.join(asset["source_location"], asset["source_name"])
                 )

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -64,7 +64,7 @@ def run_kubernetes(
             to apply to job pod.  Useful for grouping jobs together in status checks.
     """
 
-    if filesystem._is_local_path(outdir):
+    if filesystem.is_local_path(outdir):
         warnings.warn(
             f"Output directory {outdir} is a local path, so it will not be accessible "
             "once the job finishes."

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -30,7 +30,6 @@ logger = logging.getLogger("fv3run")
 
 
 def call_via_subprocess(module):
-
     def decorator(func):
         signature = inspect.signature(func)
 
@@ -200,6 +199,6 @@ if __name__ == "__main__":
     # Remove this main block after some time if it never gets triggered.
     warnings.warn(
         "calling fv3config.fv3run._native is deprecated, call fv3config.fv3run._native_main instead",
-        DeprecationWarning
+        DeprecationWarning,
     )
     run_native.main(sys.argv)

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -117,14 +117,18 @@ def _add_oversubscribe_if_necessary(mpi_flags, n_processes):
 
 @contextlib.contextmanager
 def _temporary_directory(outdir):
+    fs = filesystem.get_fs(outdir)
+    # if not filesystem.is_local_path(outdir):
     with tempfile.TemporaryDirectory() as tempdir:
         try:
             yield tempdir
         finally:
             logger.info("Copying output to %s", outdir)
-            fs = filesystem.get_fs(outdir)
             fs.makedirs(outdir, exist_ok=True)
             filesystem._put_directory(tempdir, outdir)
+    # else:
+    #     fs.makedirs(outdir, exist_ok=True)
+    #     yield outdir
 
 
 @contextlib.contextmanager

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -118,17 +118,17 @@ def _add_oversubscribe_if_necessary(mpi_flags, n_processes):
 @contextlib.contextmanager
 def _temporary_directory(outdir):
     fs = filesystem.get_fs(outdir)
-    # if not filesystem.is_local_path(outdir):
-    with tempfile.TemporaryDirectory() as tempdir:
-        try:
-            yield tempdir
-        finally:
-            logger.info("Copying output to %s", outdir)
-            fs.makedirs(outdir, exist_ok=True)
-            filesystem._put_directory(tempdir, outdir)
-    # else:
-    #     fs.makedirs(outdir, exist_ok=True)
-    #     yield outdir
+    if not filesystem.is_local_path(outdir):
+        with tempfile.TemporaryDirectory() as tempdir:
+            try:
+                yield tempdir
+            finally:
+                logger.info("Copying output to %s", outdir)
+                fs.makedirs(outdir, exist_ok=True)
+                filesystem._put_directory(tempdir, outdir)
+    else:
+        fs.makedirs(outdir, exist_ok=True)
+        yield outdir
 
 
 @contextlib.contextmanager

--- a/fv3config/fv3run/_native_main.py
+++ b/fv3config/fv3run/_native_main.py
@@ -1,0 +1,5 @@
+import sys
+from ._native import run_native
+
+if __name__ == "__main__":
+    run_native.main(sys.argv)

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -419,7 +419,7 @@ def test_get_local_paths(config_dict, local_paths):
 def test_call_via_subprocess_command():
     import json
 
-    @call_via_subprocess
+    @call_via_subprocess(__name__)
     def dummy_function(*obj, **kwargs):
         pass
 
@@ -435,7 +435,7 @@ def test_call_via_subprocess_main():
     # support return arguments
     output = []
 
-    @call_via_subprocess
+    @call_via_subprocess(__name__)
     def dummy_function(*obj):
         output.append(hash(obj))
 
@@ -456,7 +456,7 @@ def test_call_via_subprocess_main():
 
 
 def test_call_via_subprocess_command_fails_with_bad_args():
-    @call_via_subprocess
+    @call_via_subprocess(__name__)
     def dummy_function(a, b):
         pass
 


### PR DESCRIPTION
Major changes:
- Added `--kubernetes` command-line flag to output a kubernetes config yaml to stdout
- When output location is set to a local path, the job now runs in that output location instead of in a temporary directory which then gets copied. This is done both to reduce copying time for large jobs, and to improve visibility of model behavior while running.

Minor changes:
- Updated `filesystem.is_local_path` naming to be package-private instead of module-private
- Fixed an issue where the subprocess-wrapped run_native lived inside an imported module, resulting in python warnings