### PR TITLE
Make output capturing an optional behavior

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ Major changes:
 
 Minor changes:
 ~~~~~~~~~~~~~
+- Control whether outputs are logged to console or not in `run_kubernetes`, `run_native`, and `run_docker`.
 - Added the flag ``--mca btl_vader_single_copy_mechanism none to mpirun in fv3run`` to mpirun in fv3run
 - Add ReadTheDocs configuration file
 - Do not require output dir and fv3config to be remote in ``run_kubernetes``
@@ -18,6 +19,8 @@ Minor changes:
 
 Breaking changes
 ~~~~~~~~~~~~~~~~
+- Print stderr and stdout to the console by default when using fv3run. Use the
+  `--capture-output` command-line flag to enable the previous behavior.
 - Refactored run_kubernetes and run_docker to call run_native via a new API serializing
   their args/kwargs as json strings. The
   fv3config version in a docker image must be greater than or equal inside a

--- a/fv3config/fv3run/__main__.py
+++ b/fv3config/fv3run/__main__.py
@@ -57,13 +57,13 @@ Will use google cloud storage key at $GOOGLE_APPLICATION_CREDENTIALS by default.
         ),
     )
     parser.add_argument(
-        '--capture-output',
-        action='store_true',
+        "--capture-output",
+        action="store_true",
         default=False,
         help="If given, save the outputs of the fv3gfs call in a outdir/stderr.log and "
         "outdir/stdout.log. Not recommended for use with docker or kubernetes. "
         "It is recommended to use default linux pipes or docker's and kuberentes' logging "
-        "functionality."
+        "functionality.",
     )
     return parser.parse_args()
 
@@ -94,7 +94,13 @@ def main():
                 keyfile=args.keyfile,
             )
     else:
-        run_native(args.config, args.outdir, runfile=args.runfile, capture_output=args.capture_output)
+        run_native(
+            args.config,
+            args.outdir,
+            runfile=args.runfile,
+            capture_output=args.capture_output,
+        )
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/fv3config/fv3run/_docker.py
+++ b/fv3config/fv3run/_docker.py
@@ -14,7 +14,12 @@ FV3RUN_MODULE = "fv3config.fv3run"
 
 
 def run_docker(
-    config_dict_or_location, outdir, docker_image, runfile=None, keyfile=None
+    config_dict_or_location,
+    outdir,
+    docker_image,
+    runfile=None,
+    keyfile=None,
+    capture_output=True,
 ):
     """Run the FV3GFS model in a docker container with the given configuration.
 
@@ -33,6 +38,9 @@ def run_docker(
             installed.
         keyfile (str, optional): location of a Google cloud storage key to use
             inside the docker container
+        capture_output (bool, optional): If true, then the stderr and stdout
+            streams will be redirected to the files `outdir/stderr.log` and `outdir/stdout.log`
+            respectively.
     """
     if keyfile is None:
         keyfile = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", None)
@@ -52,7 +60,10 @@ def run_docker(
     runfile_in_docker = _get_runfile_args(runfile, bind_mount_args)
 
     python_command = run_native.command(
-        config_dict, DOCKER_OUTDIR, runfile=runfile_in_docker
+        config_dict,
+        DOCKER_OUTDIR,
+        runfile=runfile_in_docker,
+        capture_output=capture_output,
     )
 
     subprocess.check_call(

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -27,6 +27,7 @@ def run_kubernetes(
     image_pull_policy="IfNotPresent",
     job_labels=None,
     submit=True,
+    capture_output=True,
 ):
     """Submit a kubernetes job to perform a fv3run operation.
 
@@ -62,6 +63,9 @@ def run_kubernetes(
             Defaults to "IfNotPresent".
         job_labels (Mapping[str, str], optional): labels provided as key-value pairs
             to apply to job pod.  Useful for grouping jobs together in status checks.
+        capture_output (bool, optional): If true, then the stderr and stdout
+            streams will be redirected to the files `outdir/stderr.log` and `outdir/stdout.log`
+            respectively.
     """
 
     if filesystem.is_local_path(outdir):
@@ -69,7 +73,9 @@ def run_kubernetes(
             f"Output directory {outdir} is a local path, so it will not be accessible "
             "once the job finishes."
         )
-    command = run_native.command(config_location, outdir, runfile=runfile)
+    command = run_native.command(
+        config_location, outdir, runfile=runfile, capture_output=capture_output
+    )
     job = _get_job(
         command,
         docker_image,

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -91,7 +91,7 @@ def run_native(
                 runfile=runfile,
                 mpi_flags=_add_oversubscribe_if_necessary(MPI_FLAGS, n_processes),
                 stdout=stdout,
-                stderr=stderr
+                stderr=stderr,
             )
 
 
@@ -178,7 +178,9 @@ def _get_python_command(runfile):
     return python_args
 
 
-def _run_experiment(dirname, n_processes, runfile, mpi_flags=None, stdout=None, stderr=None):
+def _run_experiment(
+    dirname, n_processes, runfile, mpi_flags=None, stdout=None, stderr=None
+):
     if mpi_flags is None:
         mpi_flags = []
 
@@ -188,7 +190,7 @@ def _run_experiment(dirname, n_processes, runfile, mpi_flags=None, stdout=None, 
         ["mpirun", "-n", str(n_processes)] + mpi_flags + python_command,
         cwd=dirname,
         stdout=stderr,
-        stderr=stdout
+        stderr=stdout,
     )
 
 

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -86,7 +86,7 @@ def run_native(
             filesystem.get_file(
                 runfile, os.path.join(localdir, os.path.basename(runfile))
             )
-        with _error_context(localdir, capture_output) as (stdout, stderr):
+        with _output_stream_context(localdir, capture_output) as (stdout, stderr):
             n_processes = get_n_processes(config_dict)
             _run_experiment(
                 localdir,
@@ -138,7 +138,7 @@ def _temporary_directory(outdir):
         yield outdir
 
 
-def _error_context_captured(localdir):
+def _captured_output_context(localdir):
     out_filename = os.path.join(localdir, STDOUT_FILENAME)
     err_filename = os.path.join(localdir, STDERR_FILENAME)
     with open(out_filename, "wb") as out_file, open(err_filename, "wb") as err_file:
@@ -153,7 +153,7 @@ def _error_context_captured(localdir):
             raise e
 
 
-def _error_context_uncaptured(localdir):
+def _uncaptured_output_context(localdir):
     try:
         yield sys.stdout, sys.stderr
     except subprocess.CalledProcessError as e:
@@ -162,12 +162,12 @@ def _error_context_uncaptured(localdir):
 
 
 @contextlib.contextmanager
-def _error_context(localdir: str, capture_output: bool):
+def _output_stream_context(localdir: str, capture_output: bool):
     logger.info("running experiment")
     if capture_output:
-        yield from _error_context_captured(localdir)
+        yield from _captured_output_context(localdir)
     else:
-        yield from _error_context_uncaptured(localdir)
+        yield from _uncaptured_output_context(localdir)
 
 
 def _get_python_command(runfile):

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -69,6 +69,9 @@ def run_native(
             a configuration dictionary
         outdir (str): location to copy the resulting run directory
         runfile (str, optional): Python model script to use in place of the default.
+        capture_output (bool, optional): If true, then the stderr and stdout
+            streams will be redirected to the files `outdir/stderr.log` and `outdir/stdout.log`
+            respectively.
     """
     _set_stacksize_unlimited()
     with _temporary_directory(outdir) as localdir:

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -45,7 +45,14 @@ def subprocess_run(config_dict, outdir):
         config_file.write(yaml.dump(config_dict))
         config_file.flush()
         subprocess.check_call(
-            ["fv3run", config_file.name, outdir, "--runfile", MOCK_RUNSCRIPT]
+            [
+                "fv3run",
+                config_file.name,
+                outdir,
+                "--runfile",
+                MOCK_RUNSCRIPT,
+                "--capture-output",
+            ]
         )
 
 

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -13,8 +13,12 @@ import pytest
 import yaml
 
 import fv3config
-from fv3config.fv3run._native import (RUNFILE_ENV_VAR, _error_context,
-                                      _get_python_command, call_via_subprocess)
+from fv3config.fv3run._native import (
+    RUNFILE_ENV_VAR,
+    _error_context,
+    _get_python_command,
+    call_via_subprocess,
+)
 
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 MOCK_RUNSCRIPT = os.path.abspath(os.path.join(TEST_DIR, "testdata/mock_runscript.py"))

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -15,7 +15,7 @@ import yaml
 import fv3config
 from fv3config.fv3run._native import (
     RUNFILE_ENV_VAR,
-    _error_context,
+    _output_stream_context,
     _get_python_command,
     call_via_subprocess,
 )
@@ -224,10 +224,10 @@ def test__get_native_python_args(monkeypatch, runfile, expected, env_var):
 _original_get_file = fv3config.filesystem.get_file
 
 
-def test__error_context_captured(tmpdir):
+def test__output_stream_context_captured(tmpdir):
     err_msg = b"error"
     out_msg = b"output"
-    with _error_context(tmpdir, True) as (stdout, stderr):
+    with _output_stream_context(tmpdir, True) as (stdout, stderr):
         stdout.write(out_msg)
         stderr.write(err_msg)
 
@@ -238,8 +238,8 @@ def test__error_context_captured(tmpdir):
         assert out_msg == f.read()
 
 
-def test__error_context_uncaptured(tmpdir):
-    with _error_context(tmpdir, False) as (stdout, stderr):
+def test__output_stream_context_uncaptured(tmpdir):
+    with _output_stream_context(tmpdir, False) as (stdout, stderr):
         assert stdout == sys.stdout
         assert stderr == sys.stderr
 


### PR DESCRIPTION
All of our runtime environments (the linux shell, docker, and kubernetes) have powerful tools for manipulating the stdout and stderr streams, but fv3run captures these streams and instead puts them in relatively inaccessible files. This makes real time debugging and monitoring of k8s jobs especially challenging. In general, it is more flexible to pipe the outputs to stderr and stdout and let the user leverage the power of linux shell, pipes, and commands like `tee` to put the outputs where they want. 

As an example

    fv3run fv3config.yml output 2> output/stderr.log > output/stdout.log

will emulate the previous behavior provided the output directory is made
first.

Changes

* Avoid redirecting stderr and stdout when using the `fv3run` CLI unless the `--capture-output` argument is passed to `run_native`. 
* add an optional argument `capture_output` to `run_native`. Unlike the CLI, it's default value is True to avoid breaking all the tests.
* Remove the `run` function in `__main__`. This does not appear to be public function, and it seems like an unnecessary layer of indirection between the argument parsing and the calls to `run_native`, etc. 
