### PR TITLE
Ignore expected warning during kubernetes get_job test

### DIFF
--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -69,6 +69,7 @@ def job_labels(request):
     return request.param
 
 
+@pytest.mark.filterwarnings("ignore:Output directory .* is a local path.*")
 def test_get_job(
     config_location,
     outdir,


### PR DESCRIPTION
This PR adds an ignore flag to the warning that the kubernetes output directory is a local path and that output data will not be available, since the use of a local path is by design in this test (and we're not trying to get output data). This PR returns the fv3config tests to a state where no warnings should be printed when they run.

I'd consider this change too small to document in the HISTORY.rst.