### PR TITLE
Feature/parallel upload

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,16 @@ History
 Latest
 ------
 
+Major changes:
+~~~~~~~~~~~~~
+- filesystem operations now manually backoff with a 1-minute max time on RuntimeError (which gcsfs often raises when it shouldn't) and gcsfs.utils.HttpError
+- `put_directory` now makes use of a thread pool to copy items in parallel.
+
+Minor changes:
+~~~~~~~~~~~~~
+- `run_docker` now works when supplying an outdir on google cloud storage
+- `put_directory` is now marked as package-private instead of module-private
+
 
 v0.3.1 (2020-04-08)
 -------------------

--- a/fv3config/filesystem.py
+++ b/fv3config/filesystem.py
@@ -8,15 +8,17 @@ from concurrent.futures import ThreadPoolExecutor
 
 try:
     import gcsfs
+    FSSPEC_ERRORS = (RuntimeError, gcsfs.utils.HttpError)
 except ImportError as err:
     gcsfs = DelayedImportError(err)
+    FSSPEC_ERRORS = RuntimeError
 try:
     import google.auth
 except ImportError as err:
     google = DelayedImportError(err)
 
 
-fsspec_backoff = backoff.on_exception(backoff.expo, RuntimeError, max_time=60)
+fsspec_backoff = backoff.on_exception(backoff.expo, FSSPEC_ERRORS, max_time=60)
 
 
 def get_fs(path: str) -> fsspec.AbstractFileSystem:

--- a/fv3config/filesystem.py
+++ b/fv3config/filesystem.py
@@ -1,7 +1,10 @@
 import os
 import fsspec
+import backoff
 from ._exceptions import DelayedImportError
 from . import caching
+from concurrent.futures import ThreadPoolExecutor
+
 
 try:
     import gcsfs
@@ -11,6 +14,9 @@ try:
     import google.auth
 except ImportError as err:
     google = DelayedImportError(err)
+
+
+fsspec_backoff = backoff.on_exception(backoff.expo, RuntimeError, max_time=60)
 
 
 def get_fs(path: str) -> fsspec.AbstractFileSystem:
@@ -61,19 +67,26 @@ def is_local_path(location):
     return _get_protocol_prefix(location) == ""
 
 
-def _put_directory(local_source_dir, dest_dir, fs=None):
+def put_directory(local_source_dir, dest_dir, fs=None, thread_pool=None):
     """Copy the contents of a local directory to a local or remote directory.
     """
     if fs is None:
         fs = get_fs(dest_dir)
+    if thread_pool is None:
+        thread_pool = ThreadPoolExecutor()
+        manage_threads = True
+    else:
+        manage_threads = False
     for token in os.listdir(local_source_dir):
         source = os.path.join(os.path.abspath(local_source_dir), token)
         dest = os.path.join(dest_dir, token)
         if os.path.isdir(source):
-            fs.makedirs(dest, exist_ok=True)
-            _put_directory(source, dest, fs)
+            fsspec_backoff(fs.makedirs)(dest, exist_ok=True)  # must be blocking call
+            put_directory(source, dest, fs=fs, thread_pool=thread_pool)
         else:
-            fs.put(source, dest)
+            thread_pool.submit(fsspec_backoff(fs.put), source, dest)
+    if manage_threads:
+        thread_pool.shutdown(wait=True)
 
 
 def get_file(source_filename: str, dest_filename: str, cache: bool = None):
@@ -98,6 +111,7 @@ def get_file(source_filename: str, dest_filename: str, cache: bool = None):
         _get_file_cached(source_filename, dest_filename)
 
 
+@fsspec_backoff
 def _get_file_uncached(source_filename, dest_filename):
     fs = get_fs(source_filename)
     fs.get(source_filename, dest_filename)
@@ -114,6 +128,7 @@ def _get_file_cached(source_filename, dest_filename):
         _get_file_uncached(cache_location, dest_filename)
 
 
+@fsspec_backoff
 def put_file(source_filename, dest_filename):
     """Copy a file from a local location to a local or remote location.
     

--- a/fv3config/fv3run/__main__.py
+++ b/fv3config/fv3run/__main__.py
@@ -92,6 +92,7 @@ def main():
                 args.dockerimage,
                 runfile=args.runfile,
                 keyfile=args.keyfile,
+                capture_output=args.capture_output,
             )
     else:
         run_native(

--- a/fv3config/fv3run/_docker.py
+++ b/fv3config/fv3run/_docker.py
@@ -58,10 +58,13 @@ def run_docker(
 
     _get_docker_args(docker_args, bind_mount_args, outdir)
     runfile_in_docker = _get_runfile_args(runfile, bind_mount_args)
-
+    if filesystem.is_local_path(outdir):
+        docker_outdir = DOCKER_OUTDIR
+    else:
+        docker_outdir = outdir
     python_command = run_native.command(
         config_dict,
-        DOCKER_OUTDIR,
+        docker_outdir,
         runfile=runfile_in_docker,
         capture_output=capture_output,
     )
@@ -136,7 +139,8 @@ def _get_local_data_bind_mounts(config_dict, bind_mount_args):
 
 
 def _get_docker_args(docker_args, bind_mount_args, outdir):
-    bind_mount_args += ["-v", f"{os.path.abspath(outdir)}:{DOCKER_OUTDIR}"]
+    if filesystem.is_local_path(outdir):
+        bind_mount_args += ["-v", f"{os.path.abspath(outdir)}:{DOCKER_OUTDIR}"]
     docker_args += ["--rm", "--user", f"{os.getuid()}:{os.getgid()}"]
 
 

--- a/fv3config/fv3run/_kubernetes.py
+++ b/fv3config/fv3run/_kubernetes.py
@@ -63,7 +63,7 @@ def run_kubernetes(
             Defaults to "IfNotPresent".
         job_labels (Mapping[str, str], optional): labels provided as key-value pairs
             to apply to job pod.  Useful for grouping jobs together in status checks.
-        capture_output (bool, optional): If true, then the stderr and stdout
+        capture_output (bool, optional): If True, then the stderr and stdout
             streams will be redirected to the files `outdir/stderr.log` and `outdir/stdout.log`
             respectively.
     """

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -132,7 +132,7 @@ def _temporary_directory(outdir):
             finally:
                 logger.info("Copying output to %s", outdir)
                 fs.makedirs(outdir, exist_ok=True)
-                filesystem._put_directory(tempdir, outdir)
+                filesystem.put_directory(tempdir, outdir)
     else:
         fs.makedirs(outdir, exist_ok=True)
         yield outdir

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ requirements = [
     "pyyaml>=5.0",
     "gcsfs>=0.4.0",
     "fsspec>=0.6.0",
+    "backoff>=1.10",
 ]
 
 setup_requirements = []


### PR DESCRIPTION
Major changes:
- filesystem operations now manually backoff with a 1-minute max time on RuntimeError (which gcsfs often raises when it shouldn't) and gcsfs.utils.HttpError
- `put_directory` now makes use of a thread pool to copy items in parallel.

Minor changes:
- `run_docker` now works when supplying an outdir on google cloud storage
- `put_directory` is now marked as package-private instead of module-private