### PR TITLE
Release v0.4.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ v0.4.0 (2020-07-09)
 Major changes:
 ~~~~~~~~~~~~~
 - the old "default" data options are removed
+- orographic_forcing is now a required configuration key
 - get_default_config() is removed, with a placeholder which says it was removed
 - ensure_data_is_downloaded is removed, with a placeholder which says it was removed
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,8 +2,8 @@
 History
 =======
 
-latest
-------
+v0.4.0 (2020-07-09)
+-------------------
 
 Major changes:
 ~~~~~~~~~~~~~
@@ -11,8 +11,8 @@ Major changes:
 - get_default_config() is removed, with a placeholder which says it was removed
 - ensure_data_is_downloaded is removed, with a placeholder which says it was removed
 
-v0.3.2 2020-04-16
------------------
+v0.3.2 (2020-04-16)
+-------------------
 
 Major changes:
 ~~~~~~~~~~~~~

--- a/fv3config/__init__.py
+++ b/fv3config/__init__.py
@@ -22,7 +22,7 @@ from .caching import CACHE_REMOTE_FILES, do_remote_caching, set_cache_dir, get_c
 
 __author__ = """Vulcan Technologies LLC"""
 __email__ = "jeremym@vulcan.com"
-__version__ = "0.3.2"
+__version__ = "0.4.0"
 
 # necessary for auto-doc generation of API for public methods
 __all__ = dir()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.2
+current_version = 0.4.0
 commit = True
 tag = True
 
@@ -20,4 +20,3 @@ ignore = E203,E501,W293,W503
 max-line-length = 88
 
 [aliases]
-

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/VulcanClimateModeling/fv3config",
-    version="0.3.2",
+    version="0.4.0",
     zip_safe=False,
 )


### PR DESCRIPTION
Update version to v0.4.0 with removal of old-style data, so we can reference it from fv3gfs-python.