### PR TITLE
updated create_rundir example to accept external arguments

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+latest
+------
+
+Minor changes:
+~~~~~~~~~~~~~
+- updated create_rundir example to accept external arguments
+
 v0.4.0 (2020-07-09)
 -------------------
 

--- a/examples/create_rundir.py
+++ b/examples/create_rundir.py
@@ -1,6 +1,7 @@
 import fv3config
 import yaml
 import argparse
+import os
 
 
 if __name__ == "__main__":
@@ -12,3 +13,6 @@ if __name__ == "__main__":
     with open(args.configfile, "r") as f:
         config = yaml.safe_load(f)
     fv3config.write_run_directory(config, args.outdir)
+
+    with open(os.path.join(args.outdir, "fv3config.yml"), "w") as f:
+        yaml.safe_dump(config, f)

--- a/examples/create_rundir.py
+++ b/examples/create_rundir.py
@@ -1,0 +1,14 @@
+import fv3config
+import yaml
+import argparse
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Create a run directory for FV3.")
+    parser.add_argument("configfile", type=str, help="yaml configuration path")
+    parser.add_argument("outdir", type=str, help="output directory")
+    args = parser.parse_args()
+
+    with open(args.configfile, "r") as f:
+        config = yaml.safe_load(f)
+    fv3config.write_run_directory(config, args.outdir)

--- a/examples/create_rundir.sh
+++ b/examples/create_rundir.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+python create_rundir.py c12_config.yml example_rundir
+cp c12_config.yml example_rundir/fv3config.yml

--- a/examples/create_rundir.sh
+++ b/examples/create_rundir.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
 python create_rundir.py c12_config.yml example_rundir
-cp c12_config.yml example_rundir/fv3config.yml

--- a/examples/create_rundir_from_remote.py
+++ b/examples/create_rundir_from_remote.py
@@ -1,6 +1,0 @@
-import fv3config
-import yaml
-
-with open("c12_config.yml", "r") as f:
-    config = yaml.safe_load(f)
-fv3config.write_run_directory(config, "example_rundir_from_remote")


### PR DESCRIPTION
@SpiderMonkey1975 needs to create a run directory so he can run the model manually using mpirun instead of via `fv3run`. This updates the example script so it can be used plug-and-play for that purpose.