### PR TITLE
Add a write_run_directory CLI

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,11 @@ History
 latest
 ------
 
+Major changes:
+~~~~~~~~~~~~~~
+
+- a new command line interface `write_run_directory`
+
 Minor changes:
 ~~~~~~~~~~~~~
 - updated create_rundir example to accept external arguments

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -19,6 +19,17 @@ sub-dictionaries. An example C12 configuration dictionary is in the `tests` dire
 
 A run directory based on a configuration can be written using :py:func:`fv3config.write_run_directory`.
 
+Shell Usage
+-----------
+
+This module installs a command line interface `write_run_directory` that can
+be used to write the run directory from a shell. For example, if the file
+`config.yaml` contains a yaml-encoded configuration dictionary
+
+    write_run_directory config.yaml rundir
+
+will write an FV3 run directory to the path `rundir`.
+
 Data Caching
 ------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -30,6 +30,7 @@ be used to write the run directory from a shell. For example, if the file
 
 will write an FV3 run directory to the path `rundir`.
 
+This module also installs a command line interface `fv3run`, which is further detailed below.
 Data Caching
 ------------
 

--- a/fv3config/cli.py
+++ b/fv3config/cli.py
@@ -1,0 +1,26 @@
+import argparse
+
+import yaml
+import fsspec
+
+import fv3config
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser("write_run_directory")
+    parser.add_argument(
+        "config", help="URI to fv3config yaml file. Supports any path used by fsspec."
+    )
+    parser.add_argument(
+        "rundir", help="Desired output directory. Must be a local directory"
+    )
+    return parser.parse_args()
+
+
+def write_run_directory():
+    args = _parse_args()
+
+    with fsspec.open(args.config) as f:
+        config = yaml.safe_load(f)
+
+    fv3config.write_run_directory(config, args.rundir)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,12 @@ setup(
         "Programming Language :: Python :: 3.7",
     ],
     description="FV3Config is used to configure and manipulate run directories for FV3GFS.",
-    entry_points={"console_scripts": ["fv3run=fv3config.fv3run.__main__:main"]},
+    entry_points={
+        "console_scripts": [
+            "fv3run=fv3config.fv3run.__main__:main",
+            "write_run_directory=fv3config.cli:write_run_directory",
+        ]
+    },
     install_requires=requirements,
     extras_require={
         "bucket-access": "gcsfs",


### PR DESCRIPTION
This commits installs a write_run_directory CLI into the user path
which can be used to write local rundirectories from local or remote
yaml files.

Resolves #3