### PR TITLE
Make asset_list_from_path public

### DIFF
--- a/fv3config/__init__.py
+++ b/fv3config/__init__.py
@@ -16,7 +16,7 @@ from .config import (
 from ._exceptions import InvalidFileError, ConfigError
 from ._datastore import ensure_data_is_downloaded
 from .fv3run import run_docker, run_native, run_kubernetes
-from ._asset_list import get_asset_dict, get_bytes_asset_dict
+from ._asset_list import get_asset_dict, get_bytes_asset_dict, asset_list_from_path
 from .caching import CACHE_REMOTE_FILES, do_remote_caching, set_cache_dir, get_cache_dir
 
 


### PR DESCRIPTION
This PR makes asset_list_from_path a public API function. This function does exactly what is needed to get the multiple files that compose a keras model added to the asset list for copying over to the run directory, but it is not currently public. 