### PR TITLE
Copy configuration dict into rundirectory

### DIFF
--- a/.jenkins/actions/test.sh
+++ b/.jenkins/actions/test.sh
@@ -82,6 +82,7 @@ deactivate
 echo "### run install and example"
 python3 -m venv venv
 . ./venv/bin/activate
+pip3 install setuptools wheel
 pip3 install -e .
 cd examples/
 ./create_rundir.sh

--- a/.jenkins/actions/test.sh
+++ b/.jenkins/actions/test.sh
@@ -82,7 +82,6 @@ deactivate
 echo "### run install and example"
 python3 -m venv venv
 . ./venv/bin/activate
-pip3 install setuptools wheel
 pip3 install -e .
 cd examples/
 ./create_rundir.sh

--- a/fv3config/_asset_list.py
+++ b/fv3config/_asset_list.py
@@ -1,4 +1,7 @@
 import os
+
+import yaml
+
 from ._datastore import (
     get_initial_conditions_directory,
     get_orographic_forcing_directory,
@@ -11,6 +14,9 @@ from fv3config._datastore import (
 )
 from ._exceptions import ConfigError
 from . import filesystem
+
+
+FV3CONFIG_YML_NAME = "fv3config.yml"
 
 
 def is_dict_or_list(option):
@@ -72,6 +78,15 @@ def get_field_table_asset(config):
     field_table_filename = get_field_table_filename(config)
     location, name = os.path.split(field_table_filename)
     return get_asset_dict(location, name, target_name="field_table")
+
+
+def get_fv3config_yaml_asset(config):
+    """An asset containing this configuration"""
+    return get_bytes_asset_dict(
+        bytes(yaml.safe_dump(config), "UTF-8"),
+        target_location=".",
+        target_name=FV3CONFIG_YML_NAME,
+    )
 
 
 def get_asset_dict(
@@ -254,6 +269,7 @@ def config_to_asset_list(config):
     asset_list.append(get_field_table_asset(config))
     asset_list.append(get_diag_table_asset(config))
     asset_list.append(get_data_table_asset(config))
+    asset_list.append(get_fv3config_yaml_asset(config))
     if "patch_files" in config:
         if is_dict_or_list(config["patch_files"]):
             asset_list += ensure_is_list(config["patch_files"])

--- a/tests/test_asset_list.py
+++ b/tests/test_asset_list.py
@@ -8,6 +8,7 @@ from fv3config._asset_list import (
     get_data_table_asset,
     get_diag_table_asset,
     get_field_table_asset,
+    get_fv3config_yaml_asset,
     get_asset_dict,
     get_bytes_asset_dict,
     ensure_is_list,
@@ -312,6 +313,17 @@ def test_bytes_asset_serializes_with_yaml():
     deserialized = yaml.safe_load(serialized)
 
     assert deserialized == asset
+
+
+def test_get_fv3config_yaml_asset(tmpdir):
+    config = {"some": "dict"}
+    asset = get_fv3config_yaml_asset(config)
+    write_asset(asset, str(tmpdir))
+
+    with open(str(tmpdir.join("fv3config.yml"))) as f:
+        loaded = yaml.safe_load(f)
+
+    assert loaded == config
 
 
 if __name__ == "__main__":

--- a/tests/test_write_run_directory.py
+++ b/tests/test_write_run_directory.py
@@ -137,4 +137,4 @@ class CacheDirectoryTests(unittest.TestCase):
         ] = "gs://vcm-fv3config/config/diag_table/default/v1.0/diag_table"
         with tempfile.TemporaryDirectory() as rundir:
             fv3config.write_run_directory(config, rundir)
-        assert "fv3config.yml" in os.listdir(rundir)
+            assert "fv3config.yml" in os.listdir(rundir)

--- a/tests/test_write_run_directory.py
+++ b/tests/test_write_run_directory.py
@@ -129,3 +129,12 @@ class CacheDirectoryTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as rundir:
             fv3config.write_run_directory(config, rundir)
         assert os.path.getmtime(cache_filename) == modification_time
+
+    def test_rundir_contains_fv3config_yml(self):
+        config = copy.deepcopy(DEFAULT_CONFIG)
+        config[
+            "diag_table"
+        ] = "gs://vcm-fv3config/config/diag_table/default/v1.0/diag_table"
+        with tempfile.TemporaryDirectory() as rundir:
+            fv3config.write_run_directory(config, rundir)
+        assert "fv3config.yml" in os.listdir(rundir)

--- a/tests/test_write_run_directory.py
+++ b/tests/test_write_run_directory.py
@@ -132,9 +132,6 @@ class CacheDirectoryTests(unittest.TestCase):
 
     def test_rundir_contains_fv3config_yml(self):
         config = copy.deepcopy(DEFAULT_CONFIG)
-        config[
-            "diag_table"
-        ] = "gs://vcm-fv3config/config/diag_table/default/v1.0/diag_table"
         with tempfile.TemporaryDirectory() as rundir:
             fv3config.write_run_directory(config, rundir)
             assert "fv3config.yml" in os.listdir(rundir)


### PR DESCRIPTION
Many uses of the python wrapper require a configuration dictionary to be
saved as a yaml file named `fv3config.yml` in the run directory root.

This PR adds this simple capability.

The test is a little tautological, but oh well...