### PR TITLE
Fix tests on Jenkins due to dependency breakage

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,8 +14,8 @@ requests
 sphinx_rtd_theme
 pytest==5.2.2
 pytest-cov==2.8.1
-gcsfs>=0.4.0
+gcsfs==0.6.2
 google-cloud-storage
-fsspec==0.6.0
+fsspec==0.8.0
 kubernetes==10.0.1
 black==19.10b0


### PR DESCRIPTION
The Jenkins tests broke due to a new gcsfs version coming out which is incompatible with the older pinned fsspec version. Updating the requirements for both packages to their latest versions and pinning them has fixed the issue.