### PR TITLE
Allow using an asset for diag_table entry

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -68,10 +68,10 @@ Key                  Type     Description
 ==================== ======== ============================================
 namelist             dict     Model namelist
 experiment_name      str      Name of experiment to use in output
-diag_table           str      location of diag_table file, or one of ("default", "grid_spec", "no_output")
+diag_table           str      location of diag_table file, or one of ("default", "grid_spec", "no_output") or an asset
 data_table           str      location of data_table file, or "default"
-initial_conditions   str      location of directory containing initial conditions data
-forcing              str      location of directory containing forcing data
+initial_conditions   str      location of directory containing initial conditions data or sequence of assets
+forcing              str      location of directory containing forcing data or sequence of assets
 orographic_forcing   str      location of directory containing orographic data
 ==================== ======== ============================================
 
@@ -127,6 +127,9 @@ without needing to deploy them to an external storage system.
 
 One can set ``config['initial_conditions']`` or ``config['forcing']``
 to a list of assets in order to specify every initial condition or forcing file individually.
+As well, the ``config['diag_table']`` entry can be set to an asset. This is useful for passing
+the diag_table as a python bytes object. The ``diag_table`` asset must have a ``target_name`` 
+set to ``diag_table``.
 
 One can use a directory to specify the initial conditions or forcing files and replace only a
 subset of the files within the that directory with the optional ``config['patch_files']`` item.

--- a/fv3config/_asset_list.py
+++ b/fv3config/_asset_list.py
@@ -68,9 +68,22 @@ def get_data_table_asset(config):
 
 def get_diag_table_asset(config):
     """Return asset for diag_table"""
-    diag_table_filename = get_diag_table_filename(config)
-    location, name = os.path.split(diag_table_filename)
-    return get_asset_dict(location, name, target_name="diag_table")
+    try:
+        target_name = config["diag_table"]["target_name"]
+        target_location = config["diag_table"]["target_location"]
+        if target_name != "diag_table" or _without_dot(target_location) != "":
+            raise ConfigError(
+                "If providing an asset dict for the diag_table entry, its target name "
+                "must be 'diag_table' and its target location must be the root of the "
+                f"run directory. Got {target_name} for target_name and "
+                f"{target_location} for target_location."
+            )
+        asset = config["diag_table"]
+    except TypeError:  # raised if config["diag_table"] is a string, not an asset dict
+        diag_table_filename = get_diag_table_filename(config)
+        location, name = os.path.split(diag_table_filename)
+        asset = get_asset_dict(location, name, target_name="diag_table")
+    return asset
 
 
 def get_field_table_asset(config):

--- a/tests/test_asset_list.py
+++ b/tests/test_asset_list.py
@@ -152,6 +152,23 @@ class AssetListTests(unittest.TestCase):
         diag_table_asset = get_diag_table_asset(config)
         self.assertEqual(diag_table_asset, DEFAULT_DIAG_TABLE_ASSET)
 
+    def test_get_diag_table_asset_user_asset(self):
+        config = DEFAULT_CONFIG.copy()
+        config["diag_table"] = DEFAULT_DIAG_TABLE_ASSET.copy()
+        diag_table_asset = get_diag_table_asset(config)
+        self.assertEqual(diag_table_asset, DEFAULT_DIAG_TABLE_ASSET)
+
+    def test_get_diag_table_asset_bad_user_asset(self):
+        config = DEFAULT_CONFIG.copy()
+        config["diag_table"] = DEFAULT_DIAG_TABLE_ASSET.copy()
+        config["diag_table"]["target_name"] = "wrong_name_for_diag_table"
+        with self.assertRaises(fv3config.ConfigError):
+            diag_table_asset = get_diag_table_asset(config)
+        config["diag_table"] = DEFAULT_DIAG_TABLE_ASSET.copy()
+        config["diag_table"]["target_location"] = "wrong_location_for_diag_table"
+        with self.assertRaises(fv3config.ConfigError):
+            diag_table_asset = get_diag_table_asset(config)
+
     def test_get_field_table_asset_default(self):
         config = DEFAULT_CONFIG.copy()
         field_table_asset = get_field_table_asset(config)

--- a/tests/test_asset_list.py
+++ b/tests/test_asset_list.py
@@ -163,11 +163,11 @@ class AssetListTests(unittest.TestCase):
         config["diag_table"] = DEFAULT_DIAG_TABLE_ASSET.copy()
         config["diag_table"]["target_name"] = "wrong_name_for_diag_table"
         with self.assertRaises(fv3config.ConfigError):
-            diag_table_asset = get_diag_table_asset(config)
+            get_diag_table_asset(config)
         config["diag_table"] = DEFAULT_DIAG_TABLE_ASSET.copy()
         config["diag_table"]["target_location"] = "wrong_location_for_diag_table"
         with self.assertRaises(fv3config.ConfigError):
-            diag_table_asset = get_diag_table_asset(config)
+            get_diag_table_asset(config)
 
     def test_get_field_table_asset_default(self):
         config = DEFAULT_CONFIG.copy()


### PR DESCRIPTION
Only being able to specify the `diag_table` as a path (either local or GCS url) makes it challenging to get the `diag_table` into a kubernetes pod. This PR allows the user to use an asset dict (including a "bytes" asset dict) for the `diag_table` object. This means a literal representation of the `diag_table` can exist within the `fv3config` object, which will ease running the model with various diag tables on the cloud.

This implementation raises a ConfigError if the user specifies the wrong target name/location for the diag_table. Another perhaps more user-friendly option would just be to overwrite whatever the user provides for these parameters with the correct name/location.