### PR TITLE
Encode bytes data using base64

### DIFF
--- a/fv3config/_asset_list.py
+++ b/fv3config/_asset_list.py
@@ -1,5 +1,6 @@
 import os
 
+import base64
 import yaml
 
 from ._datastore import (
@@ -143,7 +144,7 @@ def get_bytes_asset_dict(
     """
 
     return {
-        "bytes": data,
+        "bytes": base64.b64encode(data).decode("UTF-8"),
         "target_location": target_location,
         "target_name": target_name,
     }
@@ -214,7 +215,7 @@ def write_asset(asset, target_directory):
         copy_file_asset(asset, target_path)
     elif "bytes" in asset:
         with open(target_path, "wb") as f:
-            f.write(asset["bytes"])
+            f.write(base64.b64decode(asset["bytes"]))
     else:
         raise ConfigError(
             "Cannot write asset. Asset must have either a `copy_method` or `bytes` key."


### PR DESCRIPTION
Currently bytes assets are serialized to yaml using the specialized `!!` notation of `yaml.safe_dump`. This is how `yaml` encodes a bytes object:
```
In [1]: import yaml

In [3]: yaml.safe_dump(b"hello world")
Out[3]: '!!binary |\n  aGVsbG8gd29ybGQ=\n'
```
It looks like it is using base64 encoding to do this. 

This will probably not be interoperable with non-python yaml parsers, so this PR introduces our own encoding strategy for bytes assets returned by `get_bytes_asset_dict`.

This change is not backwards compatible since old `fv3config.yml's` with `bytes` assets will not work with this new code. I don't think we will run into any problems since we have never actually tried to re-run past runs with old `fv3config.yml`'s, and the `bytes_asset_dict` feature is relatively recent.

Nonetheless, we may want to introduce some kind of versioning strategy for serializing/deserializing fv3config.ymls if only to warn the user if they try to load an out of date fv3config.yml.