### PR TITLE
Remove network dependency of test suite

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,8 @@ Major changes:
 
 - a new public function `fv3gfs.get_bytes_asset_dict`
 - a new command line interface `write_run_directory`
+- removed integration tests for run_docker and run_native which actually executed the model
+- all tests are now offline, using a mocked in-memory gcsfs to represent remote communication.
 
 Minor changes:
 ~~~~~~~~~~~~~

--- a/fv3config/__init__.py
+++ b/fv3config/__init__.py
@@ -16,7 +16,7 @@ from .config import (
 from ._exceptions import InvalidFileError, ConfigError
 from ._datastore import ensure_data_is_downloaded
 from .fv3run import run_docker, run_native, run_kubernetes
-from ._asset_list import get_asset_dict, get_bytes_asset_dict
+from ._asset_list import get_asset_dict, get_bytes_asset_dict, asset_list_from_path
 from .caching import CACHE_REMOTE_FILES, do_remote_caching, set_cache_dir, get_cache_dir
 
 

--- a/fv3config/filesystem.py
+++ b/fv3config/filesystem.py
@@ -24,6 +24,14 @@ fsspec_backoff = backoff.on_exception(backoff.expo, FSSPEC_ERRORS, max_time=60)
 
 def get_fs(path: str) -> fsspec.AbstractFileSystem:
     """Return the fsspec filesystem required to handle a given path."""
+    return _get_fs(path)
+
+
+def _get_fs(path: str) -> fsspec.AbstractFileSystem:
+    """Private function implementing public get_fs function, used so that if we
+    mock this implementation, it is still used in modules which import using
+    `from filesystem import get_fs`.
+    """
     if path.startswith("gs://"):
         return fsspec.filesystem("gs")
     else:

--- a/tests/c12_config.yml
+++ b/tests/c12_config.yml
@@ -1,7 +1,7 @@
 data_table: default
 diag_table: default
 experiment_name: default
-forcing: "gs://vcm-fv3config/data/base_forcing/v1.1/"
+forcing: gs://vcm-fv3config/data/base_forcing/v1.1/
 orographic_forcing: gs://vcm-fv3config/data/orographic_data/v1.0
 initial_conditions: gs://vcm-fv3config/data/initial_conditions/gfs_c12_example/v1.0 
 namelist:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,77 @@
 import pytest
 import os
+import io
 import yaml
+import fsspec
+from fsspec.implementations.memory import MemoryFileSystem
+import fv3config.filesystem
+import fv3config.data
 
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
+
+MOCK_FS_FILENAMES = [
+    "vcm-fv3config/data/initial_conditions/gfs_c12_example/v1.0/initial_conditions_file",
+    "vcm-fv3config/data/base_forcing/v1.1/forcing_file",
+    "vcm-fv3config/data/base_forcing/v1.1/grb/grb_forcing_file",
+    "vcm-fv3config/data/orographic_data/v1.0/C12/orographic_file",
+]
+DIAG_TABLE_PATH = "gs://vcm-fv3config/config/diag_table/default/v1.0/diag_table"
+
+
+def populate_mock_filesystem(fs):
+    for filename in MOCK_FS_FILENAMES:
+        fs.mkdir(os.path.dirname(filename))
+        with fs.open(filename, mode='wb') as f:
+            f.write(b"mock_data")
+    with open(os.path.join(fv3config.data.DATA_DIR, "diag_table/diag_table_default"), "r") as f_in:
+        with fs.open(DIAG_TABLE_PATH, 'w') as f_out:
+            f_out.write(f_in.read())
+    for filename in MOCK_FS_FILENAMES:
+        dirname = os.path.dirname(filename)
+        fs.ls(dirname)
+
+
+class MockGCSFileSystem(MemoryFileSystem):
+
+    protocol = "gcs", "gs"
+
+    def ls(self, path, recursive=False, **kwargs):
+        path = self._strip_protocol(path)
+        result = super().ls(path, **kwargs)
+        return super().ls(path, **kwargs)
+    
+    def mkdir(self, path, create_parents=True, **kwargs):
+        path = self._strip_protocol(path)
+        return super().mkdir(path, create_parents, **kwargs)
+
+    def rmdir(self, path, *args, **kwargs):
+        path = self._strip_protocol(path)
+        return super().rmdir(path, *args, **kwargs)
+    
+    def exists(self, path):
+        path = self._strip_protocol(path)
+        return path in self.store or path in self.pseudo_dirs
+
+    def open(self, path, *args, **kwargs):
+        path = self._strip_protocol(path)
+        return super().open(path, *args, **kwargs)
+
+
+@pytest.fixture(autouse=True)
+def mock_gs_fs():
+    memory_fs = MockGCSFileSystem()
+    populate_mock_filesystem(memory_fs)
+
+    def mock_get_fs(path: str) -> fsspec.AbstractFileSystem:
+        """Return the fsspec filesystem required to handle a given path."""
+        if path.startswith("gs://"):
+            return memory_fs  # mock gs storage using a memory filesystem
+        else:
+            return fsspec.filesystem("file")
+
+    _get_fs, fv3config.filesystem._get_fs = fv3config.filesystem._get_fs, mock_get_fs
+    yield
+    fv3config.filesystem._get_fs = _get_fs
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,10 +21,12 @@ DIAG_TABLE_PATH = "gs://vcm-fv3config/config/diag_table/default/v1.0/diag_table"
 def populate_mock_filesystem(fs):
     for filename in MOCK_FS_FILENAMES:
         fs.mkdir(os.path.dirname(filename))
-        with fs.open(filename, mode='wb') as f:
+        with fs.open(filename, mode="wb") as f:
             f.write(b"mock_data")
-    with open(os.path.join(fv3config.data.DATA_DIR, "diag_table/diag_table_default"), "r") as f_in:
-        with fs.open(DIAG_TABLE_PATH, 'w') as f_out:
+    with open(
+        os.path.join(fv3config.data.DATA_DIR, "diag_table/diag_table_default"), "r"
+    ) as f_in:
+        with fs.open(DIAG_TABLE_PATH, "w") as f_out:
             f_out.write(f_in.read())
     for filename in MOCK_FS_FILENAMES:
         dirname = os.path.dirname(filename)
@@ -39,7 +41,7 @@ class MockGCSFileSystem(MemoryFileSystem):
         path = self._strip_protocol(path)
         result = super().ls(path, **kwargs)
         return super().ls(path, **kwargs)
-    
+
     def mkdir(self, path, create_parents=True, **kwargs):
         path = self._strip_protocol(path)
         return super().mkdir(path, create_parents, **kwargs)
@@ -47,7 +49,7 @@ class MockGCSFileSystem(MemoryFileSystem):
     def rmdir(self, path, *args, **kwargs):
         path = self._strip_protocol(path)
         return super().rmdir(path, *args, **kwargs)
-    
+
     def exists(self, path):
         path = self._strip_protocol(path)
         return path in self.store or path in self.pseudo_dirs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,9 +27,6 @@ def populate_mock_filesystem(fs):
     ) as f_in:
         with fs.open(DIAG_TABLE_PATH, "w") as f_out:
             f_out.write(f_in.read())
-    for filename in MOCK_FS_FILENAMES:
-        dirname = os.path.dirname(filename)
-        fs.ls(dirname)
 
 
 class MockGCSFileSystem(MemoryFileSystem):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 import os
-import io
 import yaml
 import fsspec
 from fsspec.implementations.memory import MemoryFileSystem
@@ -39,7 +38,6 @@ class MockGCSFileSystem(MemoryFileSystem):
 
     def ls(self, path, recursive=False, **kwargs):
         path = self._strip_protocol(path)
-        result = super().ls(path, **kwargs)
         return super().ls(path, **kwargs)
 
     def mkdir(self, path, create_parents=True, **kwargs):

--- a/tests/test_forcingdata.py
+++ b/tests/test_forcingdata.py
@@ -125,9 +125,7 @@ class ForcingTests(unittest.TestCase):
         rundir = self.make_run_directory("test_rundir")
         config = DEFAULT_CONFIG.copy()
         asset_list = get_initial_conditions_asset_list(config)
-        print("assets", asset_list)
         write_asset_list(asset_list, rundir)
-        print("asset write dir", os.listdir(rundir))
         self.assert_subpaths_present(
             rundir, required_default_initial_conditions_filenames
         )

--- a/tests/test_forcingdata.py
+++ b/tests/test_forcingdata.py
@@ -24,44 +24,11 @@ with open(os.path.join(TEST_DIRECTORY, "c12_config.yml"), "r") as f:
 
 required_run_directory_subdirectories = ["INPUT", "RESTART"]
 
-required_base_forcing_filenames = (
-    [f"co2historicaldata_{year}.txt" for year in range(2010, 2017)]
-    + [
-        "sfc_emissivity_idx.txt",
-        "solarconstant_noaa_an.txt",
-        "aerosol.dat",
-        "INPUT/global_o3prdlos.f77",
-    ]
-    + [
-        "grb/CFSR.SEAICE.1982.2012.monthly.clim.grb",
-        "grb/global_snoclim.1.875.grb",
-        "grb/RTGSST.1982.2012.monthly.clim.grb",
-        "grb/global_snowfree_albedo.bosu.t1534.3072.1536.rg.grb",
-        "grb/global_albedo4.1x1.grb",
-        "grb/global_soilmgldas.t1534.3072.1536.grb",
-        "grb/global_glacier.2x2.grb",
-        "grb/global_soiltype.statsgo.t1534.3072.1536.rg.grb",
-        "grb/global_maxice.2x2.grb",
-        "grb/global_tg3clim.2.6x1.5.grb",
-        "grb/global_mxsnoalb.uariz.t1534.3072.1536.rg.grb",
-        "grb/global_vegfrac.0.144.decpercent.grb",
-        "grb/global_shdmax.0.144x0.144.grb",
-        "grb/global_vegtype.igbp.t1534.3072.1536.rg.grb",
-        "grb/global_shdmin.0.144x0.144.grb",
-        "grb/seaice_newland.grb",
-        "grb/global_slope.1x1.grb",
-    ]
-)
+required_base_forcing_filenames = ["forcing_file", "grb/grb_forcing_file"]
 
-required_orographic_forcing_filenames = [
-    f"INPUT/oro_data.tile{tile}.nc" for tile in range(1, 7)
-]
+required_orographic_forcing_filenames = ["INPUT/orographic_file"]
 
-required_default_initial_conditions_filenames = (
-    ["INPUT/gfs_ctrl.nc"]
-    + [f"INPUT/gfs_data.tile{n}.nc" for n in range(1, 7)]
-    + [f"INPUT/sfc_data.tile{n}.nc" for n in range(1, 7)]
-)
+required_default_initial_conditions_filenames = ["INPUT/initial_conditions_file"]
 
 required_restart_initial_conditions_filenames = (
     ["INPUT/coupler.res"]
@@ -158,7 +125,9 @@ class ForcingTests(unittest.TestCase):
         rundir = self.make_run_directory("test_rundir")
         config = DEFAULT_CONFIG.copy()
         asset_list = get_initial_conditions_asset_list(config)
+        print("assets", asset_list)
         write_asset_list(asset_list, rundir)
+        print("asset write dir", os.listdir(rundir))
         self.assert_subpaths_present(
             rundir, required_default_initial_conditions_filenames
         )

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -124,6 +124,7 @@ def check_run_directory(dirname):
     assert "INPUT" in filenames
 
 
+@pytest.mark.filterwarnings("ignore:could not remove stacksize limit")
 @pytest.mark.parametrize("runner", [config_dict_module_run, config_dict_filename_run])
 def test_fv3run_with_mocked_subprocess(runner, config):
     outdir = os.path.join(TEST_DIR, "outdir")
@@ -157,33 +158,6 @@ def test_fv3run_with_mocked_subprocess(runner, config):
             open(os.path.join(outdir, "fv3config.yml"), "r")
         )
         assert written_config == config
-
-
-@pytest.mark.skipif(
-    not DOCKER_ENABLED,
-    reason=f"docker or docker image {DOCKER_IMAGE_NAME} is not available",
-)
-def test_fv3run_docker(config):
-    """End-to-end test of running a mock runscript inside a docker container.
-    """
-    outdir = os.path.join(TEST_DIR, "outdir")
-
-    with cleaned_up_directory(outdir):
-        fv3config.run_docker(
-            config, outdir, DOCKER_IMAGE_NAME, runfile=MOCK_RUNSCRIPT,
-        )
-        check_run_directory(outdir)
-
-
-@pytest.mark.skipif(not MPI_ENABLED, reason="mpirun must be available")
-@pytest.mark.parametrize(
-    "runner", [subprocess_run, config_dict_module_run, config_dict_filename_run]
-)
-def test_fv3run_with_mpi(runner, config):
-    outdir = os.path.join(TEST_DIR, "outdir")
-    with cleaned_up_directory(outdir):
-        runner(config, outdir)
-        check_run_directory(outdir)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR modifies the test suite to run fully offline. It makes two changes:
- while the tests are running, get_fs is modified so it returns a MemoryFileSystem which accepts paths with a gs protocol
- run_docker tests which actually run the model are removed. This feature is deprecated, and also sufficiently tested by unit tests on run command generation

This was done for a few reasons:
- it is generally good practice to have your tests not depend on network connectivity, to avoid intermittent failures
- we are making our google cloud buckets private, and can no longer depend on the data which was being accessed
- we would like to avoid egress fees when running tests on Piz Daint