### PR TITLE
Check for coupler.res among all assets

### DIFF
--- a/fv3config/_datastore.py
+++ b/fv3config/_datastore.py
@@ -1,7 +1,6 @@
 import os
 
 from .caching import get_internal_cache_dir
-from .config.derive import get_resolution
 from .data import DATA_DIR
 from ._exceptions import ConfigError
 from . import filesystem
@@ -20,6 +19,28 @@ FIELD_TABLE_OPTIONS = {
     "GFDLMP": "field_table_GFDLMP",
     "ZhaoCarr": "field_table_ZhaoCarr",
 }
+
+
+def get_resolution(config):
+    """Get the model resolution based on a configuration dictionary.
+
+    Args:
+        config (dict): a configuration dictionary
+
+    Returns:
+        resolution (str): a model resolution (e.g. 'C48' or 'C96')
+
+    Raises:
+        ConfigError: if the number of processors in x and y on a tile are unequal
+    """
+    npx = config["namelist"]["fv_core_nml"]["npx"]
+    npy = config["namelist"]["fv_core_nml"]["npy"]
+    if npx != npy:
+        raise ConfigError(
+            f"npx and npy in fv_core_nml must be equal, but are {npx} and {npy}"
+        )
+    resolution = f"C{npx-1}"
+    return resolution
 
 
 def get_orographic_forcing_directory(config):

--- a/fv3config/config/derive.py
+++ b/fv3config/config/derive.py
@@ -101,28 +101,6 @@ def _get_coupler_res_filename(config):
     return source_path
 
 
-def get_resolution(config):
-    """Get the model resolution based on a configuration dictionary.
-
-    Args:
-        config (dict): a configuration dictionary
-
-    Returns:
-        resolution (str): a model resolution (e.g. 'C48' or 'C96')
-
-    Raises:
-        ConfigError: if the number of processors in x and y on a tile are unequal
-    """
-    npx = config["namelist"]["fv_core_nml"]["npx"]
-    npy = config["namelist"]["fv_core_nml"]["npy"]
-    if npx != npy:
-        raise ConfigError(
-            f"npx and npy in fv_core_nml must be equal, but are {npx} and {npy}"
-        )
-    resolution = f"C{npx-1}"
-    return resolution
-
-
 def get_timestep(config):
     """Get the model timestep from a configuration dictionary.
 

--- a/fv3config/config/derive.py
+++ b/fv3config/config/derive.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 import fsspec
 from .._exceptions import ConfigError
 from .default import NAMELIST_DEFAULTS
-from ..filesystem import get_fs
 from .._asset_list import config_to_asset_list
 
 

--- a/fv3config/config/derive.py
+++ b/fv3config/config/derive.py
@@ -96,6 +96,11 @@ def _get_coupler_res_filename(config):
     source_path = None
     for item in asset_list:
         if item["target_name"] == "coupler.res" and item["target_location"] == "INPUT":
+            if "bytes" in item:
+                raise NotImplementedError(
+                    "Using a bytes dict to represent a coupler.res file is not "
+                    "implemented yet. Use a standard asset dict for this item."
+                )
             source_path = os.path.join(item["source_location"], item["source_name"])
     return source_path
 

--- a/tests/test_nudging.py
+++ b/tests/test_nudging.py
@@ -152,7 +152,6 @@ def test__is_nudging_asset(item, pattern, expected):
 
 
 def test_update_config_for_nudging(test_config):
-    # tmpdir.mkdir("C12").join("orographic forcing file")
     url = "/path/to/nudging/files"
     pattern = "%Y%m%d_%H.nc"
     old_nudging_file = "20151231_18.nc"

--- a/tests/test_nudging.py
+++ b/tests/test_nudging.py
@@ -5,6 +5,11 @@ from fv3config.config import nudging
 import fv3config
 
 
+@pytest.fixture
+def test_config(c12_config):
+    return c12_config
+
+
 @pytest.mark.parametrize(
     "start_time, interval, expected",
     [
@@ -146,29 +151,21 @@ def test__is_nudging_asset(item, pattern, expected):
     assert nudging._is_nudging_asset(item, pattern) == expected
 
 
-def test_update_config_for_nudging(tmpdir):
-    tmpdir.mkdir("C12").join("orographic forcing file")
+def test_update_config_for_nudging(test_config):
+    # tmpdir.mkdir("C12").join("orographic forcing file")
     url = "/path/to/nudging/files"
     pattern = "%Y%m%d_%H.nc"
     old_nudging_file = "20151231_18.nc"
     new_nudging_file = "20160101_06.nc"
     old_asset = fv3config.get_asset_dict(url, old_nudging_file, target_location="INPUT")
     new_asset = fv3config.get_asset_dict(url, new_nudging_file, target_location="INPUT")
-    test_config = {
-        "data_table": "default",
-        "diag_table": "default",
-        "forcing": str(tmpdir),
-        "gfs_analysis_data": {"url": url, "filename_pattern": pattern},
-        "initial_conditions": str(tmpdir),
-        "namelist": {
-            "coupler_nml": {"current_date": [2016, 1, 1, 0, 0, 0], "hours": 12},
-            "fv_core_nml": {"npx": 13, "npy": 13},
-            "fv_nwp_nudge_nml": {"file_names": [f"INPUT/{old_nudging_file}"]},
-            "gfs_physics_nml": {"imp_physics": 11, "ncld": 5},
-        },
-        "orographic_forcing": str(tmpdir),
-        "patch_files": [old_asset],
+    test_config["gfs_analysis_data"] = {"url": url, "filename_pattern": pattern}
+    test_config["namelist"]["coupler_nml"]["current_date"] = [2016, 1, 1, 0, 0, 0]
+    test_config["namelist"]["coupler_nml"]["hours"] = 12
+    test_config["namelist"]["fv_nwp_nudge_nml"] = {
+        "file_names": [f"INPUT/{old_nudging_file}"]
     }
+    test_config["patch_files"] = [old_asset]
 
     fv3config.update_config_for_nudging(test_config)
 

--- a/tests/test_nudging.py
+++ b/tests/test_nudging.py
@@ -146,7 +146,8 @@ def test__is_nudging_asset(item, pattern, expected):
     assert nudging._is_nudging_asset(item, pattern) == expected
 
 
-def test_update_config_for_nudging():
+def test_update_config_for_nudging(tmpdir):
+    tmpdir.mkdir("C12").join("orographic forcing file")
     url = "/path/to/nudging/files"
     pattern = "%Y%m%d_%H.nc"
     old_nudging_file = "20151231_18.nc"
@@ -154,12 +155,18 @@ def test_update_config_for_nudging():
     old_asset = fv3config.get_asset_dict(url, old_nudging_file, target_location="INPUT")
     new_asset = fv3config.get_asset_dict(url, new_nudging_file, target_location="INPUT")
     test_config = {
+        "data_table": "default",
+        "diag_table": "default",
+        "forcing": str(tmpdir),
         "gfs_analysis_data": {"url": url, "filename_pattern": pattern},
-        "initial_conditions": "/path/to/initial_conditions",
+        "initial_conditions": str(tmpdir),
         "namelist": {
             "coupler_nml": {"current_date": [2016, 1, 1, 0, 0, 0], "hours": 12},
+            "fv_core_nml": {"npx": 13, "npy": 13},
             "fv_nwp_nudge_nml": {"file_names": [f"INPUT/{old_nudging_file}"]},
+            "gfs_physics_nml": {"imp_physics": 11, "ncld": 5},
         },
+        "orographic_forcing": str(tmpdir),
         "patch_files": [old_asset],
     }
 

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1,4 +1,5 @@
 import unittest
+import copy
 import os
 import shutil
 from fv3config import ConfigError
@@ -76,19 +77,19 @@ class TableTests(unittest.TestCase):
         return full_path
 
     def test_default_data_table_filename(self):
-        config = DEFAULT_CONFIG.copy()
+        config = copy.deepcopy(DEFAULT_CONFIG)
         filename = get_data_table_filename(config)
         self.assertTrue(os.path.isfile(filename))
         self.assertTrue("data_table" in filename)
 
     def test_default_diag_table_filename(self):
-        config = DEFAULT_CONFIG.copy()
+        config = copy.deepcopy(DEFAULT_CONFIG)
         filename = get_diag_table_filename(config)
         self.assertTrue(os.path.isfile(filename))
         self.assertTrue("diag_table" in filename)
 
     def test_default_field_table_filename(self):
-        config = DEFAULT_CONFIG.copy()
+        config = copy.deepcopy(DEFAULT_CONFIG)
         filename = get_field_table_filename(config)
         self.assertTrue(os.path.isfile(filename))
         self.assertTrue("field_table" in filename)
@@ -97,7 +98,7 @@ class TableTests(unittest.TestCase):
         source_rundir = self.make_run_directory("source_rundir")
         data_table_filename = os.path.join(source_rundir, "data_table")
         open(data_table_filename, "w").close()
-        config = DEFAULT_CONFIG.copy()
+        config = copy.deepcopy(DEFAULT_CONFIG)
         config["data_table"] = data_table_filename
         filename = get_data_table_filename(config)
         self.assertEqual(filename, data_table_filename)
@@ -106,26 +107,26 @@ class TableTests(unittest.TestCase):
         source_rundir = self.make_run_directory("source_rundir")
         diag_table_filename = os.path.join(source_rundir, "diag_table")
         open(diag_table_filename, "w").close()
-        config = DEFAULT_CONFIG.copy()
+        config = copy.deepcopy(DEFAULT_CONFIG)
         config["diag_table"] = diag_table_filename
         filename = get_diag_table_filename(config)
         self.assertEqual(filename, diag_table_filename)
 
     def test_get_bad_field_table_filename(self):
-        config = DEFAULT_CONFIG.copy()
+        config = copy.deepcopy(DEFAULT_CONFIG)
         config["namelist"]["gfs_physics_nml"]["imp_physics"] = -1
         with self.assertRaises(NotImplementedError):
             get_field_table_filename(config)
 
     def test_get_bad_microphysics_name_from_config(self):
-        config = DEFAULT_CONFIG.copy()
+        config = copy.deepcopy(DEFAULT_CONFIG)
         config["namelist"]["gfs_physics_nml"]["imp_physics"] = -1
         with self.assertRaises(NotImplementedError):
             get_microphysics_name(config)
 
     def test_get_bad_diag_table_filename(self):
         diag_table_filename = "/not/a/path/diag_table"
-        config = DEFAULT_CONFIG.copy()
+        config = copy.deepcopy(DEFAULT_CONFIG)
         config["diag_table"] = diag_table_filename
         with self.assertRaises(ConfigError):
             get_diag_table_filename(config)
@@ -161,10 +162,32 @@ class TableTests(unittest.TestCase):
         with self.assertRaises(ConfigError):
             _get_current_date_from_coupler_res(coupler_res_filename)
 
-    def test_get_current_date_from_config(self):
-        config = DEFAULT_CONFIG.copy()
+    def test_get_current_date_from_config_force_date_true(self):
+        config = copy.deepcopy(DEFAULT_CONFIG)
         config["namelist"]["coupler_nml"]["force_date_from_namelist"] = True
         config["namelist"]["coupler_nml"]["current_date"] = valid_current_date
+        current_date = get_current_date(config)
+        self.assertEqual(current_date, valid_current_date)
+
+    def test_get_current_date_from_config_force_date_false(self):
+        config = copy.deepcopy(DEFAULT_CONFIG)
+        config["namelist"]["coupler_nml"]["force_date_from_namelist"] = False
+        config["namelist"]["coupler_nml"]["current_date"] = valid_current_date
+        current_date = get_current_date(config)
+        self.assertEqual(current_date, valid_current_date)
+
+    def test_get_current_date_from_config_which_includes_coupler_res_asset(self):
+        config = copy.deepcopy(DEFAULT_CONFIG)
+        tmpdir = self.make_run_directory("test_dir")
+        config["patch_files"] = {
+            "source_location": tmpdir,
+            "source_name": "coupler.res",
+            "target_location": "INPUT",
+            "target_name": "coupler.res",
+            "copy_method": "copy",
+        }
+        with open(os.path.join(tmpdir, "coupler.res"), "w") as f:
+            f.write(valid_coupler_res)
         current_date = get_current_date(config)
         self.assertEqual(current_date, valid_current_date)
 

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -191,6 +191,13 @@ class TableTests(unittest.TestCase):
         current_date = get_current_date(config)
         self.assertEqual(current_date, valid_current_date)
 
+    def test_get_current_date_from_config_empty_initial_conditions(self):
+        config = copy.deepcopy(DEFAULT_CONFIG)
+        config["initial_conditions"] = []
+        config["namelist"]["coupler_nml"]["current_date"] = valid_current_date
+        current_date = get_current_date(config)
+        self.assertEqual(current_date, valid_current_date)
+
     def test_update_diag_table_for_config(self):
         rundir = self.make_run_directory("test_rundir")
         diag_table_filename = os.path.join(rundir, "diag_table")

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -7,6 +7,7 @@ from fv3config._tables import update_diag_table_for_config
 from fv3config.config.derive import (
     get_current_date,
     _get_current_date_from_coupler_res,
+    _get_coupler_res_filename,
 )
 from fv3config._datastore import (
     get_microphysics_name,
@@ -190,6 +191,16 @@ class TableTests(unittest.TestCase):
             f.write(valid_coupler_res)
         current_date = get_current_date(config)
         self.assertEqual(current_date, valid_current_date)
+
+    def test_get_coupler_res_filename_from_bytes_coupler_res_asset(self):
+        config = copy.deepcopy(DEFAULT_CONFIG)
+        config["patch_files"] = {
+            "bytes": b"some data",
+            "target_location": "INPUT",
+            "target_name": "coupler.res",
+        }
+        with self.assertRaises(NotImplementedError):
+            _get_coupler_res_filename(config)
 
     def test_get_current_date_from_config_empty_initial_conditions(self):
         config = copy.deepcopy(DEFAULT_CONFIG)


### PR DESCRIPTION
Check for the existence of `coupler.res` amongst all assets of given configuration dictionary. This fixes a bug introduced in #104 which required `initial_conditions` to be a path, whereas it can also be an asset or list of assets.

As part of this:
1. move `get_resolution` from `derive.py` to `_datastore.py` (this is the only module in which this function is used)
1. add two tests of `get_current_date` which exercise the two code paths of that function which are not currently tested