### PR TITLE
Fix getting coupler_res filename when using directory for initial conditions

### DIFF
--- a/fv3config/config/derive.py
+++ b/fv3config/config/derive.py
@@ -95,7 +95,8 @@ def _get_coupler_res_filename(config):
     asset_list = config_to_asset_list(config)
     source_path = None
     for item in asset_list:
-        if item["target_name"] == "coupler.res" and item["target_location"] == "INPUT":
+        target_path = os.path.join(item["target_name"], item["target_location"])
+        if target_path == "INPUT/coupler.res":
             if "bytes" in item:
                 raise NotImplementedError(
                     "Using a bytes dict to represent a coupler.res file is not "

--- a/fv3config/config/derive.py
+++ b/fv3config/config/derive.py
@@ -95,7 +95,7 @@ def _get_coupler_res_filename(config):
     asset_list = config_to_asset_list(config)
     source_path = None
     for item in asset_list:
-        target_path = os.path.join(item["target_name"], item["target_location"])
+        target_path = os.path.join(item["target_location"], item["target_name"])
         if target_path == "INPUT/coupler.res":
             if "bytes" in item:
                 raise NotImplementedError(

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -16,6 +16,7 @@ from fv3config._datastore import (
     get_data_table_filename,
 )
 import yaml
+import tempfile
 
 TEST_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 
@@ -220,6 +221,16 @@ class TableTests(unittest.TestCase):
         )
         with open(diag_table_filename) as f:
             self.assertEqual(diag_table_test_out, f.read())
+
+def test_get_coupler_res_filename_from_dir():
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    with tempfile.TemporaryDirectory() as initial_conditions_dir:
+        coupler_res_filename = os.path.join(initial_conditions_dir, "coupler.res")
+        with open(coupler_res_filename, "w") as f:
+            f.write(valid_coupler_res)
+        config["initial_conditions"] = initial_conditions_dir
+        result = _get_coupler_res_filename(config)
+        assert result == coupler_res_filename
 
 
 if __name__ == "__main__":

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -222,6 +222,7 @@ class TableTests(unittest.TestCase):
         with open(diag_table_filename) as f:
             self.assertEqual(diag_table_test_out, f.read())
 
+
 def test_get_coupler_res_filename_from_dir():
     config = copy.deepcopy(DEFAULT_CONFIG)
     with tempfile.TemporaryDirectory() as initial_conditions_dir:


### PR DESCRIPTION
Fixes bug (and adds test) for getting coupler res filename when using a directory for initial conditions. Bug happened because if statement checked if `target_location` was equal to `INPUT` but `asset_list_from_path` returned `INPUT/`. Fixes bug by using joined path in `_get_coupler_res_filename`.