### PR TITLE
Explicitly install wheel before requirements to remove wheel error messages

### DIFF
--- a/.jenkins/actions/test.sh
+++ b/.jenkins/actions/test.sh
@@ -72,6 +72,7 @@ if [ ! -f requirements_dev.txt ] ; then
 fi
 python3 -m venv venv
 . ./venv/bin/activate
+pip3 install wheel
 pip3 install -r requirements_dev.txt
 pip3 install -e .
 pytest --junitxml results.xml tests

--- a/.jenkins/actions/test.sh
+++ b/.jenkins/actions/test.sh
@@ -83,6 +83,7 @@ deactivate
 echo "### run install and example"
 python3 -m venv venv
 . ./venv/bin/activate
+pip3 install wheel
 pip3 install -e .
 cd examples/
 ./create_rundir.sh


### PR DESCRIPTION
While not failling, tests are cluttered with error messages along the lines `error: invalid command 'bdist_wheel'`. This fixes this by pre-pip-installing wheel.