### PR TITLE
Fix date retrieval from coupler_res to use get_fs instead of fsspec.open

### DIFF
--- a/fv3config/config/derive.py
+++ b/fv3config/config/derive.py
@@ -1,7 +1,6 @@
 import os
 import re
 from datetime import timedelta
-import fsspec
 from .._exceptions import ConfigError
 from .default import NAMELIST_DEFAULTS
 from .._asset_list import config_to_asset_list

--- a/fv3config/config/derive.py
+++ b/fv3config/config/derive.py
@@ -5,6 +5,7 @@ import fsspec
 from .._exceptions import ConfigError
 from .default import NAMELIST_DEFAULTS
 from .._asset_list import config_to_asset_list
+from ..filesystem import get_fs
 
 
 def get_n_processes(config):
@@ -80,7 +81,8 @@ def _get_current_date_from_coupler_res(coupler_res_filename):
     Returns:
         list: current_date as list of ints [year, month, day, hour, min, sec]
     """
-    with fsspec.open(coupler_res_filename, mode="r") as f:
+    fs = get_fs(coupler_res_filename)
+    with fs.open(coupler_res_filename, mode="r") as f:
         third_line = f.readlines()[2]
         current_date = [int(d) for d in re.findall(r"\d+", third_line)]
         if len(current_date) != 6:


### PR DESCRIPTION
Use the fv3config `get_fs` to instantiate the fileststem used to grab the coupler.res file when getting the date date instead of `fsspec.open`.  This ensures that anything in the public `fv3config` bucket will have the `requester_pays=True` in the `GCSFSFilesystem` creation.