### PR TITLE
Add backoff to requirements_dev.txt

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,6 +4,7 @@ wheel==0.33.6
 watchdog==0.9.0
 flake8==3.7.8
 tox==3.14.0
+backoff==1.10
 coverage==4.5.4
 Sphinx==1.8.5
 twine==1.14.0


### PR DESCRIPTION
backoff is a package requirement already listed in setup.py. This PR adds it to requirements_dev.txt. This is required to get readthedocs to build again.