### PR TITLE
Validate md5 checksum of gcs downloads

### DIFF
--- a/fv3config/filesystem.py
+++ b/fv3config/filesystem.py
@@ -9,7 +9,7 @@ from concurrent.futures import ThreadPoolExecutor, Executor
 try:
     import gcsfs
 
-    FSSPEC_ERRORS = (RuntimeError, gcsfs.utils.HttpError)
+    FSSPEC_ERRORS = (RuntimeError, gcsfs.utils.HttpError, gcsfs.utils.ChecksumError)
 except ImportError as err:
     gcsfs = DelayedImportError(err)
     FSSPEC_ERRORS = RuntimeError
@@ -33,7 +33,7 @@ def _get_fs(path: str) -> fsspec.AbstractFileSystem:
     `from filesystem import get_fs`.
     """
     if path.startswith("gs://"):
-        return fsspec.filesystem("gs", requester_pays=True)
+        return fsspec.filesystem("gs", requester_pays=True, consistency="md5")
     else:
         return fsspec.filesystem("file")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ f90nml>=1.1.0
 appdirs>=1.4.0
 requests>=2.22.0
 pyyaml>=5.0
-gcsfs>=0.6.0
+gcsfs>=0.7.0
 fsspec>=0.8.0
 backoff>=1.10

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -15,7 +15,7 @@ requests
 sphinx_rtd_theme
 pytest==5.2.2
 pytest-cov==2.8.1
-gcsfs==0.6.2
+gcsfs==0.7.0
 google-cloud-storage
 fsspec==0.8.0
 kubernetes==10.0.1


### PR DESCRIPTION
I've been getting corrupted file errors occasionally. Needed to bump gcs version to 0.7.0 to get the `gcsfs.utils.ChecksumError`.

Resolves #117