### PR TITLE
Release/v0.5.1

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,4 +1,3 @@
-=======
 History
 =======
 
@@ -23,7 +22,7 @@ Major changes:
 - Add CLI entry points for enable_restart and update_config_for_nudging.
 
 Minor changes:
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 - updated create_rundir example to accept external arguments
 - refactor get_current_date function to not require the path to the INPUT directory.
 
@@ -41,12 +40,12 @@ v0.3.2 (2020-04-16)
 -------------------
 
 Major changes:
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 - filesystem operations now manually backoff with a 1-minute max time on RuntimeError (which gcsfs often raises when it shouldn't) and gcsfs.utils.HttpError
 - `put_directory` now makes use of a thread pool to copy items in parallel.
 
 Minor changes:
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 - `run_docker` now works when supplying an outdir on google cloud storage
 - `put_directory` is now marked as package-private instead of module-private
 
@@ -55,11 +54,11 @@ v0.3.1 (2020-04-08)
 -------------------
 
 Major changes:
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 - Add get_timestep and config_from_yaml functions
 
 Minor changes:
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 - Allow config_to_yaml to write to remote locations
 - Control whether outputs are logged to console or not in `run_kubernetes`, `run_native`, and `run_docker`.
 
@@ -73,11 +72,11 @@ v0.3.0 (2020-04-03)
 -------------------
 
 Major changes:
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 - Added `--kubernetes` command-line flag to output a kubernetes config yaml to stdout
 
 Minor changes:
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 - Added the flag ``--mca btl_vader_single_copy_mechanism none to mpirun in fv3run`` to mpirun in fv3run
 - Add ReadTheDocs configuration file
 - Do not require output dir and fv3config to be remote in ``run_kubernetes``

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,7 +36,7 @@ v0.4.0 (2020-07-09)
 -------------------
 
 Major changes:
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 - the old "default" data options are removed
 - orographic_forcing is now a required configuration key
 - get_default_config() is removed, with a placeholder which says it was removed

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 History
 =======
 
+
+v0.5.1
+------
+
+- Fix formatting of this changelog for PyPI
+
 v0.5.0
 ------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@
 include HISTORY.rst
 include LICENSE
 include README.rst
+include requirements.txt
 
 recursive-include fv3config/data *
 

--- a/fv3config/__init__.py
+++ b/fv3config/__init__.py
@@ -24,7 +24,7 @@ from .caching import CACHE_REMOTE_FILES, do_remote_caching, set_cache_dir, get_c
 
 __author__ = """Vulcan Technologies LLC"""
 __email__ = "jeremym@vulcan.com"
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 # necessary for auto-doc generation of API for public methods
 __all__ = dir()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0
+current_version = 0.5.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/VulcanClimateModeling/fv3config",
-    version="0.5.0",
+    version="0.5.1",
     zip_safe=False,
 )


### PR DESCRIPTION
I needed to fix some errors that prevented this package from being uploaded to and installed from pypi. I figured I may as well combine these changes with a new release PR to minimize the red tape.

I have tested this on PyPI's testing server: https://test.pypi.org/project/fv3config/.

Here are the docs I used for future reference: https://realpython.com/pypi-publish-python-package/

Resolves #120.