### PR TITLE
Add logging to writing of run directory

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 History
 =======
 
+Latest
+------
+
+- Add logging to write_run_directory command
 
 v0.5.1
 ------

--- a/fv3config/_asset_list.py
+++ b/fv3config/_asset_list.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import yaml
@@ -17,6 +18,7 @@ from . import filesystem
 
 
 FV3CONFIG_YML_NAME = "fv3config.yml"
+logger = logging.getLogger("fv3config")
 
 
 def is_dict_or_list(option):
@@ -213,6 +215,7 @@ def write_asset(asset, target_directory):
     if "copy_method" in asset:
         copy_file_asset(asset, target_path)
     elif "bytes" in asset:
+        logger.debug(f"Writing asset bytes to {target_path}.")
         with open(target_path, "wb") as f:
             f.write(asset["bytes"])
     else:
@@ -226,8 +229,10 @@ def copy_file_asset(asset, target_path):
     source_path = os.path.join(asset["source_location"], asset["source_name"])
     copy_method = asset["copy_method"]
     if copy_method == "copy":
+        logger.debug(f"Copying asset from {source_path} to {target_path}.")
         filesystem.get_file(source_path, target_path)
     elif copy_method == "link":
+        logger.debug(f"Linking asset from {source_path} to {target_path}.")
         link_file(source_path, target_path)
     else:
         raise ConfigError(

--- a/fv3config/config/nudging.py
+++ b/fv3config/config/nudging.py
@@ -100,7 +100,7 @@ def _non_nudging_assets(
 
 
 def _is_nudging_asset(item, pattern):
-    if not isinstance(item, collections.Mapping):
+    if not isinstance(item, collections.abc.Mapping):
         # not an asset
         return False
     try:

--- a/fv3config/config/rundir.py
+++ b/fv3config/config/rundir.py
@@ -1,8 +1,11 @@
+import logging
 import os
 from .namelist import config_to_namelist
 from .._asset_list import write_assets_to_directory
 from .._tables import update_diag_table_for_config
 from .derive import get_current_date
+
+logger = logging.getLogger("fv3config")
 
 
 def write_run_directory(config, target_directory):
@@ -12,6 +15,7 @@ def write_run_directory(config, target_directory):
         config (dict): a configuration dictionary
         target_directory (str): target directory, will be created if it does not exist
     """
+    logger.debug(f"Writing run directory to {target_directory}")
     write_assets_to_directory(config, target_directory)
     os.makedirs(os.path.join(target_directory, "RESTART"), exist_ok=True)
     current_date = get_current_date(config)


### PR DESCRIPTION
This will aid in debugging if the `write_run_directory` command fails. It is also useful for monitoring, especially when many assets are being copied and `write_run_directory` takes minutes to complete.

Resolves #115 

Edit: also fixes an unrelated warning about importing from collections instead of collections.abc