### PR TITLE
DiagTable class

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,11 @@ History
 Latest
 ------
 
+Major changes:
+~~~~~~~~~~~~~~
+
+- add DiagTable class with associated DiagTableFile and DiagTableField dataclasses.
+
 
 v0.5.2 (2021-02-04)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,7 +7,10 @@ Latest
 Major changes:
 ~~~~~~~~~~~~~~
 
-- add DiagTable class with associated DiagTableFile and DiagTableField dataclasses.
+- add `DiagTable` class with associated `DiagFileConfig` and `DiagFieldConfig` dataclasses.
+- make `fv3config.config_to_yaml` a public function.
+- update `fv3config.config_to_yaml` and `fv3config.config_from_yaml` to go between
+  `fv3config.DiagTable` and `dict` types as necessary when serializing/deserializing
 
 
 v0.5.2 (2021-02-04)
@@ -31,7 +34,7 @@ Breaking changes:
 Major changes:
 ~~~~~~~~~~~~~~
 
-- a new public function `fv3gfs.get_bytes_asset_dict`
+- a new public function `fv3config.get_bytes_asset_dict`
 - a new command line interface `write_run_directory`
 - removed integration tests for run_docker and run_native which actually executed the model
 - all tests are now offline, using a mocked in-memory gcsfs to represent remote communication.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -228,10 +228,9 @@ The same ``DiagTable`` can also be initialized programmatically as follows:
 String representations of the ``diag_table`` (i.e. those expected by the Fortran model) can be parsed
 with the :py:meth:`fv3config.DiagTable.from_str` method.
 
-If serializing an ``fv3config`` configuration object to yaml, it is recommended to use the
-:py:meth:`fv3config.DiagTable.asdict` method before dumping the configuration dictionary. This
-method is called by :py:meth:`fv3config.config_to_yaml` if the ``diag_table`` item of the
-configuration dictionary is a ``DiagTable`` instance.
+If serializing an ``fv3config`` configuration object to yaml it is recommended to use
+:py:meth:`fv3config.config_to_yaml`. This method will convert any ``DiagTable`` instances to
+dicts (using :py:meth:`fv3config.DiagTable.asdict`), which can be safely serialized.
 
 
 Running the model with fv3run

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -158,7 +158,7 @@ for the string representation of the ``diag_table``
 package defines a python representation of this object, :py:class:`~fv3config.DiagTable`, which can
 be used to explicitly represent the ``diag_table`` within an fv3config configuration dictionary.
 
-The ``DiagTable`` object can be initialized from a dict (serialized as YAML) as follows. Suppose
+The ``DiagTable`` object can be initialized from a dict (here serialized as YAML) as follows. Suppose
 the following is saved within ``sample_diag_table.yaml``:
 
 .. code-block:: yaml
@@ -177,7 +177,7 @@ the following is saved within ``sample_diag_table.yaml``:
         module_name: gfs_phys
         output_name: upward_longwave_radiative_flux_at_toa
 
-Then:
+Then a ``DiagTable`` object can be initialized as:
 
 .. code-block:: python
 
@@ -202,35 +202,36 @@ The same ``DiagTable`` can also be initialized programmatically as follows:
     >>> import fv3config
     >>> import datetime
     >>> diag_table = fv3config.DiagTable(
-        name="example_diag_table",
-        base_time=datetime.datetime(2000, 1, 1)
-        file_configs=[
-            fv3config.DiagFileConfig(
-                name="physics_diagnostics",
-                frequency=1,
-                frequency_units="hours",
-                field_configs=[
-                    fv3config.DiagFieldConfig(
-                        "gfs_phys",
-                        "totprcb_ave"
-                        "surface_precipitation_rate"
-                    ),
-                    fv3config.DiagFieldConfig(
-                        "gfs_phys",
-                        "ULWRFtoa"
-                        "upward_longwave_radiative_flux_at_toa"
-                    ),
-                ]
-            )
-        ]
-    )
+            name="example_diag_table",
+            base_time=datetime.datetime(2000, 1, 1)
+            file_configs=[
+                fv3config.DiagFileConfig(
+                    name="physics_diagnostics",
+                    frequency=1,
+                    frequency_units="hours",
+                    field_configs=[
+                        fv3config.DiagFieldConfig(
+                            "gfs_phys",
+                            "totprcb_ave"
+                            "surface_precipitation_rate"
+                        ),
+                        fv3config.DiagFieldConfig(
+                            "gfs_phys",
+                            "ULWRFtoa"
+                            "upward_longwave_radiative_flux_at_toa"
+                        ),
+                    ]
+                )
+            ]
+        )
 
-String representations of the `diag_table` (i.e. those expected by the Fortran model) can be parsed
+String representations of the ``diag_table`` (i.e. those expected by the Fortran model) can be parsed
 with the :py:meth:`fv3config.DiagTable.from_str` method.
 
-If serializing an `fv3config` configuration object to yaml, it is recommended to use the
-:py:meth:`fv3config.DiagTable.asdict` method before dumping the configuration dictionary. This is called by
-by :py:meth:`fv3config.config_to_yaml`.
+If serializing an ``fv3config`` configuration object to yaml, it is recommended to use the
+:py:meth:`fv3config.DiagTable.asdict` method before dumping the configuration dictionary. This
+method is called by :py:meth:`fv3config.config_to_yaml` if the ``diag_table`` item of the
+configuration dictionary is a ``DiagTable`` instance.
 
 
 Running the model with fv3run

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -75,17 +75,17 @@ Configuration
 
 The ``config`` dictionary must have at least the following items:
 
-==================== ======== ============================================
-Key                  Type     Description
-==================== ======== ============================================
-namelist             dict     Model namelist
-experiment_name      str      Name of experiment to use in output
-diag_table           str      location of diag_table file, or one of ("default", "grid_spec", "no_output")
-data_table           str      location of data_table file, or "default"
-initial_conditions   str      location of directory containing initial conditions data
-forcing              str      location of directory containing forcing data
-orographic_forcing   str      location of directory containing orographic data
-==================== ======== ============================================
+==================== ======================================== ============================================
+Key                  Type                                     Description
+==================== ======================================== ============================================
+namelist             dict                                     Model namelist
+experiment_name      str                                      Name of experiment to use in output
+diag_table           str or :py:class:`~fv3config.DiagTable`  location of diag_table file, or one of ("default", "grid_spec", "no_output"), or DiagTable object
+data_table           str                                      location of data_table file, or "default"
+initial_conditions   str                                      location of directory containing initial conditions data
+forcing              str                                      location of directory containing forcing data
+orographic_forcing   str                                      location of directory containing orographic data
+==================== ======================================== ============================================
 
 Paths to files or directories on the local
 filesystem must be given as absolute paths. If paths are given that begin with ``gs://`` then ``fv3config`` will
@@ -95,6 +95,10 @@ must be installed and authorized to download from the specified bucket.
 The ``namelist`` item is special in that it is explicitly stored in the ``config`` dictionary. For the
 fv3gfs model, individual namelists are specified for various components of the model. As an example, the
 vertical resolution can be accessed via ``config['namelist']['fv_core_nml']['npz']``.
+
+The ``diag_table`` can be either be a tag or path to a file, or it can explicitly represent
+the desired output diagnostics with a :py:class:`~fv3config.DiagTable` object. See a more complete
+description of this object below.
 
 By default, fv3config attempts to automatically select the ``field_table`` file
 to use for the model based on the selected microphysics scheme in the
@@ -144,6 +148,60 @@ One can use a directory to specify the initial conditions or forcing files and r
 subset of the files within the that directory with the optional ``config['patch_files']`` item.
 All assets defined in ``config['patch_files']`` will overwrite any files specified in the
 initial conditions or forcing if they have the same target location and name.
+
+DiagTable configuration
+-----------------------
+
+The ``diag_table`` specifies the diagnostics to be output by the Fortran model. See documentation
+for the string representation of the ``diag_table``
+`here <https://mom6.readthedocs.io/en/latest/api/generated/pages/Diagnostics.html>`_. The fv3config
+package defines a python representation of this object, :py:class:`~fv3config.DiagTable`, which can
+be used to explicitly represent the ``diag_table`` within an fv3config configuration dictionary.
+
+The ``DiagTable`` object can be initialized from a dict as follows:
+
+.. code-block:: python
+
+    >>> import fv3config
+    >>> from datetime import datetime
+    >>> diag_table_dict = {
+        "name": "example_diag_table",
+        "base_time": datetime(2000, 1, 1),
+        "files": [
+            {
+                "name": "physics_diagnostics",
+                "frequency": 1,
+                "frequency_units": "hours",
+                "fields": [
+                    {
+                        "module_name": "gfs_phys",
+                        "field_name": "totprcpb_ave",
+                        "output_name": "surface_precipitation_rate",
+                    },
+                    {
+                        "module_name": "gfs_phys",
+                        "field_name": "ULWRFtoa",
+                        "output_name": "upward_longwave_radiative_flux_at_toa",
+                    }
+                ]
+            }
+        ]
+    }
+    >>> diag_table = fv3config.DiagTable.from_dict(diag_table_dict)
+    >>> print(diag_table)  # will output diag_table format expected by Fortran model
+    example_diag_table
+    2000 1 1 0 0 0
+
+    "physics_diagnostics", 1, "hours", 1, "hours", "time"
+
+    "gfs_phys", "totprcpb_ave", "surface_precipitation_rate", "physics_diagnostics", "all", "none", "none", 2
+    "gfs_phys", "ULWRFtoa", "upward_longwave_radiative_flux_at_toa", "physics_diagnostics", "all", "none", "none", 2
+
+String representations of the `diag_table` can be parsed with the :py:meth:`fv3config.DiagTable.from_str` method.
+
+If serializing an `fv3config` configuration object to yaml, it is recommended to use the
+:py:meth:`fv3config.DiagTable.asdict` method before dumping the configuration dictionary. This is implemented
+by :py:meth:`fv3config.config_to_yaml`.
 
 
 Running the model with fv3run

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -158,35 +158,33 @@ for the string representation of the ``diag_table``
 package defines a python representation of this object, :py:class:`~fv3config.DiagTable`, which can
 be used to explicitly represent the ``diag_table`` within an fv3config configuration dictionary.
 
-The ``DiagTable`` object can be initialized from a dict as follows:
+The ``DiagTable`` object can be initialized from a dict (serialized as YAML) as follows. Suppose
+the following is saved within ``sample_diag_table.yaml``:
+
+.. code-block:: yaml
+
+    name: example_diag_table
+    base_time: 2000-01-01 00:00:00
+    file_configs:
+    - name: physics_diagnostics
+      frequency: 1
+      frequency_units: hours
+      field_configs:
+      - field_name: totprcpb_ave
+        module_name: gfs_phys
+        output_name: surface_precipitation_rate
+      - field_name: ULWRFtoa
+        module_name: gfs_phys
+        output_name: upward_longwave_radiative_flux_at_toa
+
+Then:
 
 .. code-block:: python
 
     >>> import fv3config
-    >>> from datetime import datetime
-    >>> diag_table_dict = {
-        "name": "example_diag_table",
-        "base_time": datetime(2000, 1, 1),
-        "files": [
-            {
-                "name": "physics_diagnostics",
-                "frequency": 1,
-                "frequency_units": "hours",
-                "fields": [
-                    {
-                        "module_name": "gfs_phys",
-                        "field_name": "totprcpb_ave",
-                        "output_name": "surface_precipitation_rate",
-                    },
-                    {
-                        "module_name": "gfs_phys",
-                        "field_name": "ULWRFtoa",
-                        "output_name": "upward_longwave_radiative_flux_at_toa",
-                    }
-                ]
-            }
-        ]
-    }
+    >>> import yaml
+    >>> with open("sample_diag_table.yaml") as f:
+            diag_table_dict = yaml.safe_load(f)
     >>> diag_table = fv3config.DiagTable.from_dict(diag_table_dict)
     >>> print(diag_table)  # will output diag_table format expected by Fortran model
     example_diag_table
@@ -197,10 +195,41 @@ The ``DiagTable`` object can be initialized from a dict as follows:
     "gfs_phys", "totprcpb_ave", "surface_precipitation_rate", "physics_diagnostics", "all", "none", "none", 2
     "gfs_phys", "ULWRFtoa", "upward_longwave_radiative_flux_at_toa", "physics_diagnostics", "all", "none", "none", 2
 
-String representations of the `diag_table` can be parsed with the :py:meth:`fv3config.DiagTable.from_str` method.
+The same ``DiagTable`` can also be initialized programmatically as follows:
+
+.. code-block:: python
+
+    >>> import fv3config
+    >>> import datetime
+    >>> diag_table = fv3config.DiagTable(
+        name="example_diag_table",
+        base_time=datetime.datetime(2000, 1, 1)
+        file_configs=[
+            fv3config.DiagFileConfig(
+                name="physics_diagnostics",
+                frequency=1,
+                frequency_units="hours",
+                field_configs=[
+                    fv3config.DiagFieldConfig(
+                        "gfs_phys",
+                        "totprcb_ave"
+                        "surface_precipitation_rate"
+                    ),
+                    fv3config.DiagFieldConfig(
+                        "gfs_phys",
+                        "ULWRFtoa"
+                        "upward_longwave_radiative_flux_at_toa"
+                    ),
+                ]
+            )
+        ]
+    )
+
+String representations of the `diag_table` (i.e. those expected by the Fortran model) can be parsed
+with the :py:meth:`fv3config.DiagTable.from_str` method.
 
 If serializing an `fv3config` configuration object to yaml, it is recommended to use the
-:py:meth:`fv3config.DiagTable.asdict` method before dumping the configuration dictionary. This is implemented
+:py:meth:`fv3config.DiagTable.asdict` method before dumping the configuration dictionary. This is called by
 by :py:meth:`fv3config.config_to_yaml`.
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -186,7 +186,7 @@ Then a ``DiagTable`` object can be initialized as:
     >>> with open("sample_diag_table.yaml") as f:
             diag_table_dict = yaml.safe_load(f)
     >>> diag_table = fv3config.DiagTable.from_dict(diag_table_dict)
-    >>> print(diag_table)  # will output diag_table format expected by Fortran model
+    >>> print(diag_table)  # will output diag_table in format expected by Fortran model
     example_diag_table
     2000 1 1 0 0 0
 

--- a/fv3config/__init__.py
+++ b/fv3config/__init__.py
@@ -11,6 +11,7 @@ from .config import (
     get_run_duration,
     set_run_duration,
     get_timestep,
+    config_to_yaml,
     config_from_yaml,
     get_nudging_assets,
     update_config_for_nudging,

--- a/fv3config/__init__.py
+++ b/fv3config/__init__.py
@@ -15,8 +15,8 @@ from .config import (
     get_nudging_assets,
     update_config_for_nudging,
     DiagTable,
-    DiagTableField,
-    DiagTableFile,
+    DiagFieldConfig,
+    DiagFileConfig,
 )
 from ._exceptions import InvalidFileError, ConfigError
 from ._datastore import ensure_data_is_downloaded

--- a/fv3config/__init__.py
+++ b/fv3config/__init__.py
@@ -14,6 +14,9 @@ from .config import (
     config_from_yaml,
     get_nudging_assets,
     update_config_for_nudging,
+    DiagTable,
+    DiagTableField,
+    DiagTableFile,
 )
 from ._exceptions import InvalidFileError, ConfigError
 from ._datastore import ensure_data_is_downloaded

--- a/fv3config/__init__.py
+++ b/fv3config/__init__.py
@@ -17,6 +17,8 @@ from .config import (
     DiagTable,
     DiagFieldConfig,
     DiagFileConfig,
+    Packing,
+    FileFormat,
 )
 from ._exceptions import InvalidFileError, ConfigError
 from ._datastore import ensure_data_is_downloaded

--- a/fv3config/_asset_list.py
+++ b/fv3config/_asset_list.py
@@ -13,6 +13,7 @@ from fv3config._datastore import (
     get_diag_table_filename,
     get_data_table_filename,
 )
+from .config.diag_table import DiagTable
 from ._exceptions import ConfigError
 from . import filesystem
 
@@ -70,9 +71,14 @@ def get_data_table_asset(config):
 
 def get_diag_table_asset(config):
     """Return asset for diag_table"""
-    diag_table_filename = get_diag_table_filename(config)
-    location, name = os.path.split(diag_table_filename)
-    return get_asset_dict(location, name, target_name="diag_table")
+    if isinstance(config["diag_table"], DiagTable):
+        return get_bytes_asset_dict(
+            bytes(str(config["diag_table"]), "UTF-8"), ".", "diag_table"
+        )
+    else:
+        diag_table_filename = get_diag_table_filename(config)
+        location, name = os.path.split(diag_table_filename)
+        return get_asset_dict(location, name, target_name="diag_table")
 
 
 def get_field_table_asset(config):

--- a/fv3config/config/__init__.py
+++ b/fv3config/config/__init__.py
@@ -8,7 +8,7 @@ from .rundir import write_run_directory
 from .alter import enable_restart, set_run_duration
 from .derive import get_n_processes, get_run_duration, get_timestep
 from .nudging import get_nudging_assets, update_config_for_nudging
-from .diag_table import DiagTableFile, DiagTableField, DiagTable
+from .diag_table import DiagFileConfig, DiagFieldConfig, DiagTable
 
 
 def get_default_config():

--- a/fv3config/config/__init__.py
+++ b/fv3config/config/__init__.py
@@ -8,6 +8,7 @@ from .rundir import write_run_directory
 from .alter import enable_restart, set_run_duration
 from .derive import get_n_processes, get_run_duration, get_timestep
 from .nudging import get_nudging_assets, update_config_for_nudging
+from .diag_table import DiagTableFile, DiagTableField, DiagTable
 
 
 def get_default_config():

--- a/fv3config/config/__init__.py
+++ b/fv3config/config/__init__.py
@@ -8,7 +8,13 @@ from .rundir import write_run_directory
 from .alter import enable_restart, set_run_duration
 from .derive import get_n_processes, get_run_duration, get_timestep
 from .nudging import get_nudging_assets, update_config_for_nudging
-from .diag_table import DiagFileConfig, DiagFieldConfig, DiagTable
+from .diag_table import (
+    DiagFileConfig,
+    DiagFieldConfig,
+    DiagTable,
+    Packing,
+    FileFormat,
+)
 
 
 def get_default_config():

--- a/fv3config/config/diag_table.py
+++ b/fv3config/config/diag_table.py
@@ -116,9 +116,6 @@ class DiagTable:
 
         return "\n".join(lines)
 
-    def __eq__(self, other):
-        return isinstance(other, self.__class__) and self.__repr__() == other.__repr__()
-
     def asdict(self):
         return {
             "name": self.name,

--- a/fv3config/config/diag_table.py
+++ b/fv3config/config/diag_table.py
@@ -116,6 +116,9 @@ class DiagTable:
 
         return "\n".join(lines)
 
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__repr__() == other.__repr__()
+
     def asdict(self):
         return {
             "name": self.name,

--- a/fv3config/config/diag_table.py
+++ b/fv3config/config/diag_table.py
@@ -1,0 +1,204 @@
+from typing import Sequence, Optional, Union
+import dataclasses
+from datetime import datetime, timedelta
+import re
+import sys
+
+from .._exceptions import ConfigError
+
+
+@dataclasses.dataclass
+class DiagTableField:
+    """Object representing a field of a diagnostics file."""
+
+    module_name: str
+    field_name: str
+    output_name: str
+    reduction_method: Optional[str] = "none"
+    time_sampling: Optional[str] = "all"
+    regional_section: Optional[str] = "none"
+    packing: Optional[int] = 2
+
+
+@dataclasses.dataclass
+class DiagTableFile:
+    """Object representing a diagnostics file."""
+
+    name: str
+    frequency: int
+    frequency_units: str
+    fields: Sequence[DiagTableField]
+    file_format: Optional[int] = 1
+    time_axis_units: Optional[str] = "hours"
+    time_axis_name: Optional[str] = "time"
+
+
+class DiagTable:
+    def __init__(
+        self, name: str, base_time: datetime, files: Sequence[DiagTableFile],
+    ):
+        """Representation of diag_table, which controls Fortran diagnostics manager.
+
+        Note:
+            This implementation is based on the diag_table specification described in
+      https://data1.gfdl.noaa.gov/summer-school/Lectures/July16/03_Seth1_DiagManager.pdf
+            The MOM6 documentation has a useful description as well:
+            https://mom6.readthedocs.io/en/latest/api/generated/pages/Diagnostics.html.
+
+        Args:
+            name: label used as attribute in output diagnostic files. Cannot contain
+                spaces.
+            base_time: time to be used as reference for time coordinate units.
+            files: sequence of DiagTableFile's defining the diagnostics to be output.
+        """
+        if " " in name:
+            raise ConfigError(f"Name for diag_table cannot have spaces. Got '{name}''.")
+        self.name = name
+        self.base_time = base_time
+        self.files = files
+
+    def __repr__(self):
+        """Representation of diag_table expected by the Fortran model."""
+        lines = []
+        lines.append(self.name)
+        lines.append(self._time_to_str(self.base_time))
+        lines.append("")
+
+        for file_ in self.files:
+            lines.append(self._file_repr(file_))
+
+        lines.append("")
+        for file_ in self.files:
+            for field in file_.fields:
+                lines.append(self._field_repr(field, file_.name))
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def _file_repr(self, file_: DiagTableFile) -> str:
+        tokens = (
+            file_.name,
+            file_.frequency,
+            file_.frequency_units,
+            file_.file_format,
+            file_.time_axis_units,
+            file_.time_axis_name,
+        )
+        return ", ".join(self._token_to_str(t) for t in tokens)
+
+    def _field_repr(self, field: DiagTableField, file_name: str) -> str:
+        tokens = (
+            field.module_name,
+            field.field_name,
+            field.output_name,
+            file_name,
+            field.time_sampling,
+            field.reduction_method,
+            field.regional_section,
+            field.packing,
+        )
+        return ", ".join(self._token_to_str(t) for t in tokens)
+
+    @staticmethod
+    def _time_to_str(time: datetime) -> str:
+        times = [time.year, time.month, time.day, time.hour, time.minute, time.second]
+        return " ".join([str(t) for t in times])
+
+    @staticmethod
+    def _str_to_time(line: str) -> datetime:
+        time_sequence = [int(d) for d in re.findall(r"\d+", line)]
+        return datetime(*time_sequence)
+
+    @staticmethod
+    def _str_to_token(arg: str) -> Union[str, int]:
+        if arg.startswith('"') and arg.endswith('"'):
+            return arg.strip('"')
+        elif arg.lower() == ".true.":
+            # reduction_method can use '.true.' or '"average"' for same meaning
+            return "average"
+        elif arg.lower() == ".false.":
+            # reduction_method can use '.false.' or '"none"' for same meaning
+            return "none"
+        else:
+            return int(arg)
+
+    @staticmethod
+    def _token_to_str(token: Union[str, int]) -> str:
+        if isinstance(token, str):
+            return f'"{token}"'
+        else:
+            return str(token)
+
+    @staticmethod
+    def _parse_line(line: str) -> Sequence[Union[str, int]]:
+
+        token_strings = line.replace(" ", "").strip(",").split(",")
+        return list(map(DiagTable._str_to_token, token_strings))
+
+    @classmethod
+    def from_str(cls, diag_table: str):
+        """Initialize DiagTable class from Fortran string representation."""
+        lines = diag_table.split("\n")
+        lines = [line for line in lines if line and line[0] != "#"]
+        parsed_lines = list(map(cls._parse_line, lines[2:]))
+
+        file_lines = []
+        field_lines = {}
+
+        for tokens in parsed_lines:
+            if len(tokens) == 6:
+                # line corresponds to definition of a file
+                file_name = tokens[0]
+                file_lines.append(tokens)
+                field_lines[file_name] = []
+            else:
+                # line corresponds to definition of a field
+                file_name = tokens[3]
+                if file_name not in field_lines:
+                    raise ConfigError(
+                        "Files must be defined before they can be used by a field in "
+                        f"diag_table. {file_name} has not been defined yet."
+                    )
+                field_lines[file_name].append(tokens)
+
+        files = []
+        for file_tokens in file_lines:
+            file_name = file_tokens[0]
+            fields = []
+            for field_tokens in field_lines[file_name]:
+                fields.append(
+                    DiagTableField(
+                        module_name=field_tokens[0],
+                        field_name=field_tokens[1],
+                        output_name=field_tokens[2],
+                        time_sampling=field_tokens[4],
+                        reduction_method=field_tokens[5],
+                        regional_section=field_tokens[6],
+                        packing=field_tokens[7],
+                    )
+                )
+            files.append(
+                DiagTableFile(
+                    name=file_name,
+                    frequency=file_tokens[1],
+                    frequency_units=file_tokens[2],
+                    fields=fields,
+                    file_format=file_tokens[3],
+                    time_axis_units=file_tokens[4],
+                    time_axis_name=file_tokens[5],
+                )
+            )
+        name = lines[0]
+        base_time = cls._str_to_time(lines[1])
+        return cls(name, base_time, files)
+
+
+if __name__ == "__main__":
+    path = sys.argv[1]
+
+    with open(path) as f:
+        input_ = f.read()
+
+    diag_table = DiagTable.from_str(input_)
+
+    print(diag_table)

--- a/fv3config/config/diag_table.py
+++ b/fv3config/config/diag_table.py
@@ -1,45 +1,86 @@
 import logging
-from typing import Sequence, Optional, Union
+from typing import Sequence, Optional, Union, Tuple, Mapping
 import dataclasses
 import datetime
+from enum import Enum
 import re
+
+
+# using Literal from typing_extensions to allow use of python 3.7
+# overloading typing.Literal since dacite does not recognize typing_extensions.Literal
+# see https://github.com/konradhalas/dacite/issues/100
+from typing_extensions import Literal
+import typing
+
+typing.Literal = Literal
+from typing import Literal
 
 import dacite
 
 from .._exceptions import ConfigError
 
 logger = logging.getLogger("fv3config")
+NUMBER_OF_TOKENS_ON_FILE_LINES = 6
+NUMBER_OF_TOKENS_ON_FIELD_LINES = 8
+
+
+class Packing(Enum):
+    DOUBLE_PRECISION = 1
+    SINGLE_PRECISION = 2
+
+
+class ReductionMethod(Enum):
+    NONE = "none"
+    AVERAGE = "average"
+    MINIMUM = "min"
+    MAXIMUM = "max"
+
+
+class TimeSampling(Enum):
+    ALL = "all"
+
+
+class FrequencyUnits(Enum):
+    YEARS = "years"
+    MONTHS = "months"
+    DAYS = "days"
+    HOURS = "hours"
+    MINUTES = "minutes"
+    SECONDS = "seconds"
 
 
 @dataclasses.dataclass
-class DiagTableField:
-    """Object representing a field of a diagnostics file."""
+class DiagFieldConfig:
+    """Object representing configuration for a field of a diagnostics file."""
 
     module_name: str
     field_name: str
     output_name: str
-    reduction_method: Optional[str] = "none"
-    time_sampling: Optional[str] = "all"
-    regional_section: Optional[str] = "none"
-    packing: Optional[int] = 2
+    reduction_method: ReductionMethod = ReductionMethod.NONE
+    time_sampling: TimeSampling = TimeSampling.ALL
+    regional_section: str = "none"
+    packing: Packing = Packing.SINGLE_PRECISION
 
 
 @dataclasses.dataclass
-class DiagTableFile:
-    """Object representing a diagnostics file."""
+class DiagFileConfig:
+    """Object representing a diagnostics file configuration."""
 
     name: str
     frequency: int
-    frequency_units: str
-    fields: Sequence[DiagTableField]
-    file_format: Optional[int] = 1
-    time_axis_units: Optional[str] = "hours"
-    time_axis_name: Optional[str] = "time"
+    frequency_units: FrequencyUnits
+    field_configs: Sequence[DiagFieldConfig]
+    file_format: Literal[1] = 1
+    time_axis_units: FrequencyUnits = FrequencyUnits.HOURS
+    time_axis_name: str = "time"
 
 
 class DiagTable:
     def __init__(
-        self, name: str, base_time: datetime.datetime, files: Sequence[DiagTableFile],
+        self,
+        name: str,
+        base_time: datetime.datetime,
+        file_configs: Sequence[DiagFileConfig],
     ):
         """Representation of diag_table, which controls Fortran diagnostics manager.
 
@@ -53,13 +94,14 @@ class DiagTable:
             name: label used as attribute in output diagnostic files. Cannot contain
                 spaces.
             base_time: time to be used as reference for time coordinate units.
-            files: sequence of DiagTableFile's defining the diagnostics to be output.
+            file_configs: sequence of DiagFileConfig's defining the diagnostics to be
+                output.
         """
         if " " in name:
             raise ConfigError(f"Name for diag_table cannot have spaces. Got '{name}'.")
         self.name = name
         self.base_time = base_time
-        self.files = files
+        self.file_configs = file_configs
 
     def __repr__(self):
         """Representation of diag_table expected by the Fortran model."""
@@ -68,12 +110,12 @@ class DiagTable:
         lines.append(self._time_to_str(self.base_time))
         lines.append("")
 
-        for file_ in self.files:
+        for file_ in self.file_configs:
             lines.append(self._file_repr(file_))
 
         lines.append("")
-        for file_ in self.files:
-            for field in file_.fields:
+        for file_ in self.file_configs:
+            for field in file_.field_configs:
                 lines.append(self._field_repr(field, file_.name))
             lines.append("")
 
@@ -83,30 +125,30 @@ class DiagTable:
         return {
             "name": self.name,
             "base_time": self.base_time,
-            "files": [dataclasses.asdict(file_) for file_ in self.files],
+            "file_configs": [dataclasses.asdict(file_) for file_ in self.file_configs],
         }
 
-    def _file_repr(self, file_: DiagTableFile) -> str:
+    def _file_repr(self, file_: DiagFileConfig) -> str:
         tokens = (
             file_.name,
             file_.frequency,
-            file_.frequency_units,
+            file_.frequency_units.value,
             file_.file_format,
-            file_.time_axis_units,
+            file_.time_axis_units.value,
             file_.time_axis_name,
         )
         return ", ".join(self._token_to_str(t) for t in tokens)
 
-    def _field_repr(self, field: DiagTableField, file_name: str) -> str:
+    def _field_repr(self, field: DiagFieldConfig, file_name: str) -> str:
         tokens = (
             field.module_name,
             field.field_name,
             field.output_name,
             file_name,
-            field.time_sampling,
-            field.reduction_method,
+            field.time_sampling.value,
+            field.reduction_method.value,
             field.regional_section,
-            field.packing,
+            field.packing.value,
         )
         return ", ".join(self._token_to_str(t) for t in tokens)
 
@@ -142,32 +184,23 @@ class DiagTable:
 
     @staticmethod
     def _parse_line(line: str) -> Sequence[Union[str, int]]:
-        token_strings = line.replace(" ", "").strip(",").split(",")
+        token_strings = line.replace(" ", "").split("#")[0].strip(",").split(",")
         return list(map(DiagTable._str_to_token, token_strings))
 
-    @classmethod
-    def from_dict(cls, diag_table: dict):
-        files = [dacite.from_dict(DiagTableFile, f) for f in diag_table["files"]]
-        return cls(diag_table["name"], diag_table["base_time"], files)
-
-    @classmethod
-    def from_str(cls, diag_table: str):
-        """Initialize DiagTable class from Fortran string representation."""
-        lines = diag_table.split("\n")
-        lines = [line for line in lines if line and line[0] != "#"]
-        parsed_lines = list(map(cls._parse_line, lines[2:]))
-
+    @staticmethod
+    def _organize_lines(
+        parsed_lines: Sequence[str],
+    ) -> Tuple[Sequence[str], Mapping[str, Sequence[str]]]:
+        """Separate lines into 1) a sequence of lines describe files and 2) a mapping of
+        file name to sequence of lines for all fields in that file."""
         file_lines = []
         field_lines = {}
-
         for tokens in parsed_lines:
-            if len(tokens) == 6:
-                # line corresponds to definition of a file
+            if len(tokens) == NUMBER_OF_TOKENS_ON_FILE_LINES:
                 file_name = tokens[0]
                 file_lines.append(tokens)
                 field_lines[file_name] = []
-            elif len(tokens) == 8:
-                # line corresponds to definition of a field
+            elif len(tokens) == NUMBER_OF_TOKENS_ON_FIELD_LINES:
                 file_name = tokens[3]
                 if file_name not in field_lines:
                     raise ConfigError(
@@ -179,34 +212,56 @@ class DiagTable:
                 logger.warning(
                     f"Ignoring a line that could not be parsed in diag_table: {tokens}"
                 )
+        return file_lines, field_lines
 
-        files = []
+    @staticmethod
+    def _construct_configs_from_lines(
+        file_lines, field_lines
+    ) -> Sequence[DiagFileConfig]:
+        file_configs = []
         for file_tokens in file_lines:
             file_name = file_tokens[0]
-            fields = []
+            field_configs = []
             for field_tokens in field_lines[file_name]:
-                fields.append(
-                    DiagTableField(
+                field_configs.append(
+                    DiagFieldConfig(
                         module_name=field_tokens[0],
                         field_name=field_tokens[1],
                         output_name=field_tokens[2],
-                        time_sampling=field_tokens[4],
-                        reduction_method=field_tokens[5],
+                        time_sampling=TimeSampling(field_tokens[4]),
+                        reduction_method=ReductionMethod(field_tokens[5]),
                         regional_section=field_tokens[6],
-                        packing=field_tokens[7],
+                        packing=Packing(field_tokens[7]),
                     )
                 )
-            files.append(
-                DiagTableFile(
+            file_configs.append(
+                DiagFileConfig(
                     name=file_name,
                     frequency=file_tokens[1],
-                    frequency_units=file_tokens[2],
-                    fields=fields,
+                    frequency_units=FrequencyUnits(file_tokens[2]),
+                    field_configs=field_configs,
                     file_format=file_tokens[3],
-                    time_axis_units=file_tokens[4],
+                    time_axis_units=FrequencyUnits(file_tokens[4]),
                     time_axis_name=file_tokens[5],
                 )
             )
+        return file_configs
+
+    @classmethod
+    def from_dict(cls, diag_table: dict):
+        file_configs = [
+            dacite.from_dict(DiagFileConfig, f) for f in diag_table["file_configs"]
+        ]
+        return cls(diag_table["name"], diag_table["base_time"], file_configs)
+
+    @classmethod
+    def from_str(cls, diag_table: str):
+        """Initialize DiagTable class from Fortran string representation."""
+        lines = diag_table.split("\n")
+        lines = [line for line in lines if line and line.strip(" ")[0] != "#"]
         name = lines[0]
         base_time = cls._str_to_time(lines[1])
-        return cls(name, base_time, files)
+        parsed_lines = list(map(cls._parse_line, lines[2:]))
+        file_lines, field_lines = cls._organize_lines(parsed_lines)
+        file_configs = cls._construct_configs_from_lines(file_lines, field_lines)
+        return cls(name, base_time, file_configs)

--- a/fv3config/config/diag_table.py
+++ b/fv3config/config/diag_table.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 import logging
 from typing import Sequence, Optional, Union
 import dataclasses

--- a/fv3config/config/diag_table.py
+++ b/fv3config/config/diag_table.py
@@ -2,9 +2,8 @@ from copy import deepcopy
 import logging
 from typing import Sequence, Optional, Union
 import dataclasses
-from datetime import datetime, timedelta
+import datetime
 import re
-import sys
 
 from .._exceptions import ConfigError
 
@@ -39,7 +38,7 @@ class DiagTableFile:
 
 class DiagTable:
     def __init__(
-        self, name: str, base_time: datetime, files: Sequence[DiagTableFile],
+        self, name: str, base_time: datetime.datetime, files: Sequence[DiagTableFile],
     ):
         """Representation of diag_table, which controls Fortran diagnostics manager.
 
@@ -111,14 +110,14 @@ class DiagTable:
         return ", ".join(self._token_to_str(t) for t in tokens)
 
     @staticmethod
-    def _time_to_str(time: datetime) -> str:
+    def _time_to_str(time: datetime.datetime) -> str:
         times = [time.year, time.month, time.day, time.hour, time.minute, time.second]
         return " ".join([str(t) for t in times])
 
     @staticmethod
-    def _str_to_time(line: str) -> datetime:
+    def _str_to_time(line: str) -> datetime.datetime:
         time_sequence = [int(d) for d in re.findall(r"\d+", line)]
-        return datetime(*time_sequence)
+        return datetime.datetime(*time_sequence)
 
     @staticmethod
     def _str_to_token(arg: str) -> Union[str, int]:

--- a/fv3config/config/diag_table.py
+++ b/fv3config/config/diag_table.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Sequence, Optional, Union
 import dataclasses
 from datetime import datetime, timedelta
@@ -5,6 +6,8 @@ import re
 import sys
 
 from .._exceptions import ConfigError
+
+logger = logging.getLogger("fv3config")
 
 
 @dataclasses.dataclass
@@ -131,7 +134,6 @@ class DiagTable:
 
     @staticmethod
     def _parse_line(line: str) -> Sequence[Union[str, int]]:
-
         token_strings = line.replace(" ", "").strip(",").split(",")
         return list(map(DiagTable._str_to_token, token_strings))
 
@@ -151,7 +153,7 @@ class DiagTable:
                 file_name = tokens[0]
                 file_lines.append(tokens)
                 field_lines[file_name] = []
-            else:
+            elif len(tokens) == 8:
                 # line corresponds to definition of a field
                 file_name = tokens[3]
                 if file_name not in field_lines:
@@ -160,6 +162,10 @@ class DiagTable:
                         f"diag_table. {file_name} has not been defined yet."
                     )
                 field_lines[file_name].append(tokens)
+            else:
+                logger.warning(
+                    f"Ignoring a line that could not be parsed in diag_table: {tokens}"
+                )
 
         files = []
         for file_tokens in file_lines:

--- a/fv3config/config/diag_table.py
+++ b/fv3config/config/diag_table.py
@@ -5,6 +5,8 @@ import dataclasses
 import datetime
 import re
 
+import dacite
+
 from .._exceptions import ConfigError
 
 logger = logging.getLogger("fv3config")
@@ -146,16 +148,7 @@ class DiagTable:
 
     @classmethod
     def from_dict(cls, diag_table: dict):
-        files = []
-        for file_ in diag_table["files"]:
-            # this recursion would be handled by the from_dict method of the dacite
-            # package. Consider adding dependence? Would also provide type checking.
-            fields = []
-            for field in file_["fields"]:
-                fields.append(DiagTableField(**field))
-            file_copy = deepcopy(file_)
-            file_copy.update(fields=fields)
-            files.append(DiagTableFile(**file_copy))
+        files = [dacite.from_dict(DiagTableFile, f) for f in diag_table["files"]]
         return cls(diag_table["name"], diag_table["base_time"], files)
 
     @classmethod

--- a/fv3config/config/diag_table.py
+++ b/fv3config/config/diag_table.py
@@ -5,16 +5,6 @@ import datetime
 from enum import Enum
 import re
 
-
-# using Literal from typing_extensions to allow use of python 3.7
-# overloading typing.Literal since dacite does not recognize typing_extensions.Literal
-# see https://github.com/konradhalas/dacite/issues/100
-from typing_extensions import Literal
-import typing
-
-typing.Literal = Literal
-from typing import Literal
-
 import dacite
 
 from .._exceptions import ConfigError
@@ -49,6 +39,10 @@ class FrequencyUnits(Enum):
     SECONDS = "seconds"
 
 
+class FileFormat(Enum):
+    NETCDF = 1
+
+
 @dataclasses.dataclass
 class DiagFieldConfig:
     """Object representing configuration for a field of a diagnostics file."""
@@ -70,7 +64,7 @@ class DiagFileConfig:
     frequency: int
     frequency_units: FrequencyUnits
     field_configs: Sequence[DiagFieldConfig]
-    file_format: Literal[1] = 1
+    file_format: FileFormat = FileFormat.NETCDF
     time_axis_units: FrequencyUnits = FrequencyUnits.HOURS
     time_axis_name: str = "time"
 
@@ -133,7 +127,7 @@ class DiagTable:
             file_.name,
             file_.frequency,
             file_.frequency_units.value,
-            file_.file_format,
+            file_.file_format.value,
             file_.time_axis_units.value,
             file_.time_axis_name,
         )
@@ -240,7 +234,7 @@ class DiagTable:
                     frequency=file_tokens[1],
                     frequency_units=FrequencyUnits(file_tokens[2]),
                     field_configs=field_configs,
-                    file_format=file_tokens[3],
+                    file_format=FileFormat(file_tokens[3]),
                     time_axis_units=FrequencyUnits(file_tokens[4]),
                     time_axis_name=file_tokens[5],
                 )

--- a/fv3config/config/diag_table.py
+++ b/fv3config/config/diag_table.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Sequence, Optional, Union, Tuple, Mapping
+from typing import Sequence, Union, Tuple, Mapping
 import dataclasses
 import datetime
 from enum import Enum
@@ -56,7 +56,7 @@ class DiagFileConfig:
         frequency_units: One of 'years', 'months', 'days', 'hours', 'minutes', 'seconds'
         field_configs: Sequence of DiagFieldConfigs defining fields to save.
         file_format: Always FileFormat.NETCDF.
-        time_axis_units: Units for time coordinate in output files. One of 'years', 
+        time_axis_units: Units for time coordinate in output files. One of 'years',
             'months', 'days', 'hours', 'minutes', 'seconds'.
         time_axis_name: Name for time coordinate in output files.
     """

--- a/fv3config/config/namelist.py
+++ b/fv3config/config/namelist.py
@@ -1,4 +1,3 @@
-import dataclasses
 import os
 import f90nml
 import fsspec

--- a/fv3config/config/namelist.py
+++ b/fv3config/config/namelist.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import os
 import f90nml
 import fsspec
@@ -8,21 +9,18 @@ from .diag_table import DiagTable
 
 
 def config_to_yaml(config, config_out_filename):
+    config_copy = deepcopy(config)
     if isinstance(config["diag_table"], DiagTable):
-        config["diag_table"] = DiagTable.asdict()
+        config_copy["diag_table"] = config["diag_table"].asdict()
     with fsspec.open(config_out_filename, "w") as outfile:
-        outfile.write(yaml.dump(config))
+        outfile.write(yaml.dump(config_copy))
 
 
 def config_from_yaml(path):
     """Return fv3config dictionary at path"""
     with fsspec.open(path) as yaml_file:
         config = yaml.safe_load(yaml_file)
-    if isinstance(config["diag_table"], str):
-        diag_table_filename = get_diag_table_filename(config)
-        with fsspec.open(diag_table_filename) as f:
-            config["diag_table"] = DiagTable.from_str(f.read())
-    else:
+    if isinstance(config["diag_table"], dict):
         config["diag_table"] = DiagTable.from_dict(config["diag_table"])
     return config
 

--- a/fv3config/config/namelist.py
+++ b/fv3config/config/namelist.py
@@ -4,7 +4,6 @@ import f90nml
 import fsspec
 import yaml
 from .._exceptions import InvalidFileError
-from .._datastore import get_diag_table_filename
 from .diag_table import DiagTable
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyyaml>=5.0
 gcsfs>=0.7.0
 fsspec>=0.8.0
 backoff>=1.10
+dacite>=1.6.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -20,3 +20,4 @@ google-cloud-storage
 fsspec==0.8.0
 kubernetes==10.0.1
 black==19.10b0
+dacite==1.6.0

--- a/tests/test_asset_list.py
+++ b/tests/test_asset_list.py
@@ -328,11 +328,11 @@ def test_get_fv3config_yaml_asset(tmpdir):
 
 
 def test_get_diag_table_asset_from_class(tmpdir):
-    field = fv3config.DiagTableField("dycore", "u850", "u850")
+    field = fv3config.DiagFieldConfig("dycore", "u850", "u850")
     diag_table = fv3config.DiagTable(
         "experiment",
         datetime.datetime(2000, 1, 1),
-        [fv3config.DiagTableFile("name", 1, "hours", [field])],
+        [fv3config.DiagFileConfig("name", 1, "hours", [field])],
     )
     asset = get_diag_table_asset({"diag_table": diag_table})
     write_asset(asset, str(tmpdir))

--- a/tests/test_asset_list.py
+++ b/tests/test_asset_list.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 import os
 import shutil
@@ -324,6 +325,22 @@ def test_get_fv3config_yaml_asset(tmpdir):
         loaded = yaml.safe_load(f)
 
     assert loaded == config
+
+
+def test_get_diag_table_asset_from_class(tmpdir):
+    field = fv3config.DiagTableField("dycore", "u850", "u850")
+    diag_table = fv3config.DiagTable(
+        "experiment",
+        datetime.datetime(2000, 1, 1),
+        [fv3config.DiagTableFile("name", 1, "hours", [field])],
+    )
+    asset = get_diag_table_asset({"diag_table": diag_table})
+    write_asset(asset, str(tmpdir))
+
+    with open(str(tmpdir.join("diag_table"))) as f:
+        loaded = f.read()
+
+    assert loaded == str(diag_table)
 
 
 if __name__ == "__main__":

--- a/tests/test_diag_table.py
+++ b/tests/test_diag_table.py
@@ -28,12 +28,12 @@ def diag_table():
 
 def test_DiagTable_string_round_trip(diag_table):
     round_tripped_diag_table = DiagTable.from_str(str(diag_table))
-    assert str(diag_table) == str(round_tripped_diag_table)
+    assert diag_table == round_tripped_diag_table
 
 
 def test_DiagTable_dict_round_trip(diag_table):
     round_tripped_diag_table = DiagTable.from_dict(diag_table.asdict())
-    assert str(diag_table) == str(round_tripped_diag_table)
+    assert diag_table == round_tripped_diag_table
 
 
 def test_DiagTable__repr__(diag_table):

--- a/tests/test_diag_table.py
+++ b/tests/test_diag_table.py
@@ -28,12 +28,12 @@ def diag_table():
 
 def test_DiagTable_string_round_trip(diag_table):
     round_tripped_diag_table = DiagTable.from_str(str(diag_table))
-    assert diag_table == round_tripped_diag_table
+    assert str(diag_table) == str(round_tripped_diag_table)
 
 
 def test_DiagTable_dict_round_trip(diag_table):
     round_tripped_diag_table = DiagTable.from_dict(diag_table.asdict())
-    assert diag_table == round_tripped_diag_table
+    assert str(diag_table) == str(round_tripped_diag_table)
 
 
 def test_DiagTable__repr__(diag_table):

--- a/tests/test_diag_table.py
+++ b/tests/test_diag_table.py
@@ -10,14 +10,14 @@ def diag_field():
 
 
 def diag_file(name):
-    return DiagTableFile(name, 1, "hours", (diag_field(), diag_field()))
+    return DiagTableFile(name, 1, "hours", [diag_field(), diag_field()])
 
 
 def test_DiagTable_string_round_trip():
     diag_table = DiagTable(
         "experiment",
         datetime(2000, 1, 1),
-        (diag_file("first_diagnostics"), diag_file("second_diagnostics")),
+        [diag_file("first_diagnostics"), diag_file("second_diagnostics")],
     )
     round_tripped_diag_table = DiagTable.from_str(str(diag_table))
     assert str(diag_table) == str(round_tripped_diag_table)
@@ -27,7 +27,7 @@ def test_DiagTable_dict_round_trip():
     diag_table = DiagTable(
         "experiment",
         datetime(2000, 1, 1),
-        (diag_file("first_diagnostics"), diag_file("second_diagnostics")),
+        [diag_file("first_diagnostics"), diag_file("second_diagnostics")],
     )
     round_tripped_diag_table = DiagTable.from_dict(diag_table.asdict())
     assert str(diag_table) == str(round_tripped_diag_table)

--- a/tests/test_diag_table.py
+++ b/tests/test_diag_table.py
@@ -13,13 +13,23 @@ def diag_file(name):
     return DiagTableFile(name, 1, "hours", (diag_field(), diag_field()))
 
 
-def test_DiagTable_round_trip():
+def test_DiagTable_string_round_trip():
     diag_table = DiagTable(
         "experiment",
         datetime(2000, 1, 1),
         (diag_file("first_diagnostics"), diag_file("second_diagnostics")),
     )
     round_tripped_diag_table = DiagTable.from_str(str(diag_table))
+    assert str(diag_table) == str(round_tripped_diag_table)
+
+
+def test_DiagTable_dict_round_trip():
+    diag_table = DiagTable(
+        "experiment",
+        datetime(2000, 1, 1),
+        (diag_file("first_diagnostics"), diag_file("second_diagnostics")),
+    )
+    round_tripped_diag_table = DiagTable.from_dict(diag_table.asdict())
     assert str(diag_table) == str(round_tripped_diag_table)
 
 

--- a/tests/test_diag_table.py
+++ b/tests/test_diag_table.py
@@ -1,0 +1,101 @@
+from datetime import datetime
+import pytest
+
+from fv3config.config.diag_table import DiagTable, DiagTableField, DiagTableFile
+from fv3config._exceptions import ConfigError
+
+
+def diag_field():
+    return DiagTableField("dynamics", "u850", "zonal_wind_at_850hPa")
+
+
+def diag_file(name):
+    return DiagTableFile(name, 1, "hours", (diag_field(), diag_field()))
+
+
+def test_DiagTable_round_trip():
+    diag_table = DiagTable(
+        "experiment",
+        datetime(2000, 1, 1),
+        (diag_file("first_diagnostics"), diag_file("second_diagnostics")),
+    )
+    round_tripped_diag_table = DiagTable.from_str(str(diag_table))
+    assert str(diag_table) == str(round_tripped_diag_table)
+
+
+def test_from_str():
+    input_str = """default_experiment
+2016 08 01 00 0 0
+#output files
+"atmos_static",           -1,  "hours",    1, "hours", "time",
+"atmos_dt_atmos",          2,  "hours",    1, "hours",  "time"
+"empty_file",              2,  "hours",    1, "hours",  "time"
+#
+#output variables
+#
+
+###
+# atmos_static
+###
+  "dynamics",      "zsurf",       "HGTsfc",       "atmos_static",      "all", .false.,  "none", 2
+###
+# atmos_dt_atmos
+###
+"dynamics",  "us",          "UGRDlowest",    "atmos_dt_atmos", "all", .false.,  "none", 2
+"dynamics",  "u850",        "UGRD850",       "atmos_dt_atmos", "all", .true.,  "none", 2
+"""
+
+    diag_table = DiagTable.from_str(input_str)
+    assert diag_table.name == "default_experiment"
+    assert diag_table.base_time == datetime(2016, 8, 1)
+    assert len(diag_table.files) == 3
+    assert diag_table.files[0] == DiagTableFile(
+        "atmos_static", -1, "hours", [DiagTableField("dynamics", "zsurf", "HGTsfc")]
+    )
+    assert diag_table.files[1] == DiagTableFile(
+        "atmos_dt_atmos",
+        2,
+        "hours",
+        [
+            DiagTableField("dynamics", "us", "UGRDlowest"),
+            DiagTableField("dynamics", "u850", "UGRD850", "average"),
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "diag_table_str",
+    [
+        """default_experiment
+2016 08 01 00 0 0
+"dynamics", "zsurf", "HGTsfc", "atmos_static", "all", .false.,  "none", 2
+"atmos_static", -1,  "hours", 1, "hours", "time"
+""",
+        """default experiment
+2016 08 01 00 0 0
+"atmos_static", -1,  "hours", 1, "hours", "time"
+"dynamics", "zsurf", "HGTsfc", "atmos_static", "all", .false.,  "none", 2
+""",
+    ],
+    ids=["field_defined_before_corresponding_file", "spaces_in_name"],
+)
+def test_from_str_raises_config_error(diag_table_str):
+    with pytest.raises(ConfigError):
+        DiagTable.from_str(diag_table_str)
+
+
+@pytest.mark.parametrize(
+    "input_,expected_output",
+    [('"name"', "name"), (".true.", "average"), (".false.", "none"), ("3", 3)],
+)
+def test__str_to_token(input_, expected_output):
+    output = DiagTable._str_to_token(input_)
+    assert output == expected_output
+
+
+@pytest.mark.parametrize(
+    "token,expected_output", [("name", '"name"'), (3, "3")],
+)
+def test__token_to_str(token, expected_output):
+    output = DiagTable._token_to_str(token)
+    assert output == expected_output

--- a/tests/test_namelist.py
+++ b/tests/test_namelist.py
@@ -235,7 +235,7 @@ def test_config_to_from_yaml_round_trip_with_DiagTable(tmpdir):
     config["diag_table"] = diag_table
     config_to_yaml(config, tmpdir.join("config.yaml"))
     round_tripped_config = config_from_yaml(tmpdir.join("config.yaml"))
-    assert config["diag_table"] == round_tripped_config["diag_table"]
+    assert config == round_tripped_config
 
 
 if __name__ == "__main__":

--- a/tests/test_namelist.py
+++ b/tests/test_namelist.py
@@ -66,7 +66,7 @@ config_with_empty_fv_core_and_coupler_nml = {
     "namelist": {"fv_core_nml": {}, "coupler_nml": {}}
 }
 
-diag_table = DiagTable(
+sample_diag_table = DiagTable(
     "sample_diag_table",
     datetime.datetime(2000, 1, 1),
     file_configs=[
@@ -232,9 +232,12 @@ def test_config_to_from_yaml_round_trip(tmpdir):
 
 def test_config_to_from_yaml_round_trip_with_DiagTable(tmpdir):
     config = DEFAULT_CONFIG.copy()
-    config["diag_table"] = diag_table
+    config["diag_table"] = sample_diag_table
     config_to_yaml(config, tmpdir.join("config.yaml"))
     round_tripped_config = config_from_yaml(tmpdir.join("config.yaml"))
+    diag_table = config.pop("diag_table")
+    round_tripped_diag_table = round_tripped_config.pop("diag_table")
+    assert str(diag_table) == str(round_tripped_diag_table)
     assert config == round_tripped_config
 
 


### PR DESCRIPTION
It is useful to have a richer representation of the `diag_table` item in fv3config configuration dictionaries.

This PR adds a `DiagTable` class and associated `DiagFileConfig` and `DiagFieldConfig` dataclasses. The `DiagTable` class has `__repr__` and `from_str` methods which allow going between the Fortran-expected string representation of the `diag_table` and the python representation. It also includes `asdict` and `from_dict` methods, which are useful for serializing/deserializing the `diag_table` item to/from YAML.

[dacite](https://github.com/konradhalas/dacite) is added as a requirement, as it provides useful functionality for going from a dict to a DataClass with type checking.

This PR does not introduce any breaking changes. If a user provides a path for the `diag_table`, that file will just be copied to the rundir as is currently done.