### PR TITLE
Update for nudging on write_run_directory if necessary

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,8 @@ Major changes:
 - make `fv3config.config_to_yaml` a public function.
 - update `fv3config.config_to_yaml` and `fv3config.config_from_yaml` to go between
   `fv3config.DiagTable` and `dict` types as necessary when serializing/deserializing
+- `write_run_directory` provisions necessary `patch_files` for config if the 
+  `fv_core_nml.nudge` option is set to `True`.
 
 
 v0.5.2 (2021-02-04)

--- a/fv3config/config/nudging.py
+++ b/fv3config/config/nudging.py
@@ -127,19 +127,29 @@ def update_config_for_nudging(config: Mapping):
     Args:
         config: configuration dictionary
 
+    Raises:
+        ConfigError: if provided config does not contain "gfs_analysis_data" section.
+
     Note:
         will delete any existing assets in 'patch_files' that match the given
         filename_pattern before new assets are added.
     """
+    gfs_analysis_data = config.get("gfs_analysis_data", {})
+    if "url" not in gfs_analysis_data or "filename_pattern" not in gfs_analysis_data:
+        raise ConfigError(
+            "Config must contain 'gfs_analysis_data' section with 'url' and"
+            "'filename_pattern' items if 'namelist.fv_core_nml.nudge' is True."
+        )
+
     _clear_nudging_assets(config)
 
     nudging_file_assets = get_nudging_assets(
         get_run_duration(config),
         get_current_date(config),
-        config["gfs_analysis_data"]["url"],
-        nudge_filename_pattern=config["gfs_analysis_data"]["filename_pattern"],
-        copy_method=config["gfs_analysis_data"].get("copy_method", "copy"),
-        nudge_interval=config["gfs_analysis_data"].get("interval", timedelta(hours=6)),
+        gfs_analysis_data["url"],
+        nudge_filename_pattern=gfs_analysis_data["filename_pattern"],
+        copy_method=gfs_analysis_data.get("copy_method", "copy"),
+        nudge_interval=gfs_analysis_data.get("interval", timedelta(hours=6)),
     )
 
     target_file_paths = [

--- a/fv3config/config/rundir.py
+++ b/fv3config/config/rundir.py
@@ -17,7 +17,7 @@ def write_run_directory(config, target_directory):
         target_directory (str): target directory, will be created if it does not exist
     """
     logger.debug(f"Writing run directory to {target_directory}")
-    if "gfs_analysis_data" in config:
+    if config["namelist"]["fv_core_nml"].get("nudge", False):
         update_config_for_nudging(config)
     write_assets_to_directory(config, target_directory)
     os.makedirs(os.path.join(target_directory, "RESTART"), exist_ok=True)

--- a/fv3config/config/rundir.py
+++ b/fv3config/config/rundir.py
@@ -4,6 +4,7 @@ from .namelist import config_to_namelist
 from .._asset_list import write_assets_to_directory
 from .._tables import update_diag_table_for_config
 from .derive import get_current_date
+from .nudging import update_config_for_nudging
 
 logger = logging.getLogger("fv3config")
 
@@ -16,6 +17,8 @@ def write_run_directory(config, target_directory):
         target_directory (str): target directory, will be created if it does not exist
     """
     logger.debug(f"Writing run directory to {target_directory}")
+    if "gfs_analysis_data" in config:
+        update_config_for_nudging(config)
     write_assets_to_directory(config, target_directory)
     os.makedirs(os.path.join(target_directory, "RESTART"), exist_ok=True)
     current_date = get_current_date(config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,8 @@ MOCK_FS_FILENAMES = [
     "vcm-fv3config/data/base_forcing/v1.1/forcing_file",
     "vcm-fv3config/data/base_forcing/v1.1/grb/grb_forcing_file",
     "vcm-fv3config/data/orographic_data/v1.0/C12/orographic_file",
+    "vcm-fv3config/data/gfs_nudging_data/v1.0/20160801_00.nc",
+    "vcm-fv3config/data/gfs_nudging_data/v1.0/20160801_06.nc",
 ]
 DIAG_TABLE_PATH = "gs://vcm-fv3config/config/diag_table/default/v1.0/diag_table"
 

--- a/tests/test_write_run_directory.py
+++ b/tests/test_write_run_directory.py
@@ -135,3 +135,14 @@ class CacheDirectoryTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as rundir:
             fv3config.write_run_directory(config, rundir)
             assert "fv3config.yml" in os.listdir(rundir)
+
+    def test_rundir_contains_nudging_asset_if_enabled(self):
+        config = copy.deepcopy(DEFAULT_CONFIG)
+        config["gfs_analysis_data"] = {
+            "url": "gs://vcm-fv3config/data/gfs_nudging_data/v1.0",
+            "filename_pattern": "%Y%m%d_%H.nc",
+        }
+        with tempfile.TemporaryDirectory() as rundir:
+            fv3config.write_run_directory(config, rundir)
+            assert "20160801_00.nc" in os.listdir(os.path.join(rundir, "INPUT"))
+            assert "20160801_06.nc" in os.listdir(os.path.join(rundir, "INPUT"))

--- a/tests/test_write_run_directory.py
+++ b/tests/test_write_run_directory.py
@@ -142,6 +142,7 @@ class CacheDirectoryTests(unittest.TestCase):
             "url": "gs://vcm-fv3config/data/gfs_nudging_data/v1.0",
             "filename_pattern": "%Y%m%d_%H.nc",
         }
+        config["namelist"]["fv_core_nml"]["nudge"] = True
         with tempfile.TemporaryDirectory() as rundir:
             fv3config.write_run_directory(config, rundir)
             assert "20160801_00.nc" in os.listdir(os.path.join(rundir, "INPUT"))


### PR DESCRIPTION
fv3config should provision the necessary `patch_files` at the time of `write_run_directory` if nudging is activated. This will simplify scripts that use `fv3config` since they won't have to do this themselves.