### PR TITLE
Replacing remains yaml usages with fv3config load/dump

### DIFF
--- a/fv3config/_asset_list.py
+++ b/fv3config/_asset_list.py
@@ -1,8 +1,6 @@
 import io
 import logging
-import os
-
-import yaml
+import osyaml
 
 from ._datastore import (
     get_initial_conditions_directory,

--- a/fv3config/_asset_list.py
+++ b/fv3config/_asset_list.py
@@ -1,6 +1,6 @@
 import io
 import logging
-import osyaml
+import os
 
 from ._datastore import (
     get_initial_conditions_directory,

--- a/fv3config/_asset_list.py
+++ b/fv3config/_asset_list.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import os
 
@@ -14,6 +15,7 @@ from fv3config._datastore import (
     get_data_table_filename,
 )
 from .config.diag_table import DiagTable
+from .config._serialization import dump
 from ._exceptions import ConfigError
 from . import filesystem
 
@@ -90,8 +92,10 @@ def get_field_table_asset(config):
 
 def get_fv3config_yaml_asset(config):
     """An asset containing this configuration"""
+    f = io.StringIO()
+    dump(config, f)
     return get_bytes_asset_dict(
-        bytes(yaml.safe_dump(config), "UTF-8"),
+        bytes(f.getvalue(), "UTF-8"),
         target_location=".",
         target_name=FV3CONFIG_YML_NAME,
     )

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -11,7 +11,7 @@ import tempfile
 import warnings
 import yaml
 import json
-from ..config import write_run_directory, get_n_processes, dump
+from ..config import write_run_directory, get_n_processes, dump, load
 from .. import filesystem
 
 STDOUT_FILENAME = "stdout.log"
@@ -212,7 +212,7 @@ def _get_config_dict_and_write(config_dict_or_location, config_out_filename):
 def _copy_and_load_config_dict(config_location, local_target_location):
     filesystem.get_file(config_location, local_target_location)
     with open(local_target_location, "r") as infile:
-        config_dict = yaml.load(infile.read(), Loader=yaml.SafeLoader)
+        config_dict = load(infile)
     return config_dict
 
 

--- a/fv3config/fv3run/_native.py
+++ b/fv3config/fv3run/_native.py
@@ -9,7 +9,6 @@ import multiprocessing
 import os
 import tempfile
 import warnings
-import yaml
 import json
 from ..config import write_run_directory, get_n_processes, dump, load
 from .. import filesystem

--- a/tests/test_asset_list.py
+++ b/tests/test_asset_list.py
@@ -317,7 +317,7 @@ def test_bytes_asset_serializes_with_yaml():
 
 
 def test_get_fv3config_yaml_asset(tmpdir):
-    config = {"some": "dict"}
+    config = {"some": "dict", "diag_table": "/path/to/diag_table"}
     asset = get_fv3config_yaml_asset(config)
     write_asset(asset, str(tmpdir))
 

--- a/tests/test_write_run_directory.py
+++ b/tests/test_write_run_directory.py
@@ -5,6 +5,7 @@ import fv3config
 import os
 import shutil
 import copy
+import datetime
 
 from .mocks import c12_config
 
@@ -135,6 +136,13 @@ class CacheDirectoryTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as rundir:
             fv3config.write_run_directory(config, rundir)
             assert "fv3config.yml" in os.listdir(rundir)
+
+    def test_write_run_directory_succeeds_with_diag_table_class(self):
+        config = copy.deepcopy(DEFAULT_CONFIG)
+        start_time = datetime.datetime(2000, 1, 1)
+        config["diag_table"] = fv3config.DiagTable("name", start_time, [])
+        with tempfile.TemporaryDirectory() as rundir:
+            fv3config.write_run_directory(config, rundir)
 
     def test_rundir_contains_nudging_asset_if_enabled(self):
         config = copy.deepcopy(DEFAULT_CONFIG)


### PR DESCRIPTION
A use of `yaml.safe_dump` within the `get_fv3config_yaml_asset` function prevented the writing of run directories when a config object contained a `DiagTable` class for the `diag_table` entry. This PR replaces that usage with `fv3config.dump` and adds a relevant test.