### PR TITLE
Ensure write_run_directory does not mutate input config

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,16 @@ History
 Latest
 ------
 
+Breaking changes:
+~~~~~~~~~~~~~~~~~
+- rename ``fv3config.update_config_for_nudging`` to ``fv3config.enable_nudging`` and make this function return a new config instead of mutating the input
+- rename ``update_config_for_nudging`` command line entrypoint to ``enable_nudging``
+
+Bug fixes:
+~~~~~~~~~~
+- ensure ``fv3config.write_run_directory`` does not mutate input config
+
+
 v0.7.1 (2021-03-18)
 -------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,7 +37,7 @@ in order to use them for restart runs:
 
 and to provision the necessary files required for a nudged run:
 
-    update_config_for_nudging config.yaml
+    enable_nudging config.yaml
 
 Both of these shell commands will modify the given configuration dictionary in place.
 
@@ -377,7 +377,7 @@ GFS analysis. Two public functions are provided to ease the configuration of nud
 
 Given the run duration and start date, :py:func:`fv3config.get_nudging_assets`
 returns a list of fv3config assets corresponding to the GFS analysis files required. Given
-an fv3config object, :py:func:`fv3config.update_config_for_nudging` will add the necessary
+an fv3config object, :py:func:`fv3config.enable_nudging` return a new config with the necessary
 assets and namelist options for a nudging run. This function requires that the fv3config
 object contains a `gfs_analysis_data` entry with corresponding `url` and `filename_pattern`
 items.

--- a/fv3config/__init__.py
+++ b/fv3config/__init__.py
@@ -12,7 +12,7 @@ from .config import (
     set_run_duration,
     get_timestep,
     get_nudging_assets,
-    update_config_for_nudging,
+    enable_nudging,
     DiagTable,
     DiagFieldConfig,
     DiagFileConfig,

--- a/fv3config/_asset_list.py
+++ b/fv3config/_asset_list.py
@@ -276,7 +276,8 @@ def check_asset_has_required_keys(asset):
 def config_to_asset_list(config):
     """Convert a configuration dictionary to an asset list. The asset list
     will contain all files for the run directory except the namelist."""
-    asset_list = get_initial_conditions_asset_list(config)
+    asset_list = []
+    asset_list += get_initial_conditions_asset_list(config)
     asset_list += get_base_forcing_asset_list(config)
     asset_list += get_orographic_forcing_asset_list(config)
     asset_list.append(get_field_table_asset(config))

--- a/fv3config/cli.py
+++ b/fv3config/cli.py
@@ -67,7 +67,7 @@ def update_config_for_nudging():
 
     # only update config if nudging is turned on
     if config["namelist"]["fv_core_nml"].get("nudge", False):
-        fv3config.update_config_for_nudging(config)
+        updated_config = fv3config.update_config_for_nudging(config)
 
         with fsspec.open(args.config, mode="w") as f:
-            fv3config.dump(config, f)
+            fv3config.dump(updated_config, f)

--- a/fv3config/cli.py
+++ b/fv3config/cli.py
@@ -28,8 +28,8 @@ def _parse_enable_restart_args():
     return parser.parse_args()
 
 
-def _parse_update_config_for_nudging_args():
-    parser = argparse.ArgumentParser("update_config_for_nudging")
+def _parse_enable_nudging_args():
+    parser = argparse.ArgumentParser("enable_nudging")
     parser.add_argument(
         "config",
         help="URI to fv3config yaml file. Supports any path used by fsspec. "
@@ -59,15 +59,15 @@ def enable_restart():
         fv3config.dump(restart_config, f)
 
 
-def update_config_for_nudging():
-    args = _parse_update_config_for_nudging_args()
+def enable_nudging():
+    args = _parse_enable_nudging_args()
 
     with fsspec.open(args.config) as f:
         config = fv3config.load(f)
 
     # only update config if nudging is turned on
     if config["namelist"]["fv_core_nml"].get("nudge", False):
-        updated_config = fv3config.update_config_for_nudging(config)
+        updated_config = fv3config.enable_nudging(config)
 
         with fsspec.open(args.config, mode="w") as f:
             fv3config.dump(updated_config, f)

--- a/fv3config/config/__init__.py
+++ b/fv3config/config/__init__.py
@@ -5,7 +5,7 @@ from .namelist import (
 from .rundir import write_run_directory
 from .alter import enable_restart, set_run_duration
 from .derive import get_n_processes, get_run_duration, get_timestep
-from .nudging import get_nudging_assets, update_config_for_nudging
+from .nudging import get_nudging_assets, enable_nudging
 from .diag_table import (
     DiagFileConfig,
     DiagFieldConfig,

--- a/fv3config/config/nudging.py
+++ b/fv3config/config/nudging.py
@@ -120,7 +120,7 @@ def _clear_nudging_assets(config):
         config["patch_files"] = _non_nudging_assets(config["patch_files"], pattern)
 
 
-def update_config_for_nudging(config: Mapping) -> Mapping:
+def enable_nudging(config: Mapping) -> Mapping:
     """Return config object with necessary nudging file assets and associated
     file_names namelist entry. Requires 'gfs_analysis_data' entry in fv3config object
     with 'url' and 'filename_pattern' entries.

--- a/fv3config/config/rundir.py
+++ b/fv3config/config/rundir.py
@@ -18,7 +18,7 @@ def write_run_directory(config, target_directory):
     """
     logger.debug(f"Writing run directory to {target_directory}")
     if config["namelist"]["fv_core_nml"].get("nudge", False):
-        update_config_for_nudging(config)
+        config = update_config_for_nudging(config)
     write_assets_to_directory(config, target_directory)
     os.makedirs(os.path.join(target_directory, "RESTART"), exist_ok=True)
     current_date = get_current_date(config)

--- a/fv3config/config/rundir.py
+++ b/fv3config/config/rundir.py
@@ -4,7 +4,7 @@ from .namelist import config_to_namelist
 from .._asset_list import write_assets_to_directory
 from .._tables import update_diag_table_for_config
 from .derive import get_current_date
-from .nudging import update_config_for_nudging
+from .nudging import enable_nudging
 
 logger = logging.getLogger("fv3config")
 
@@ -18,7 +18,7 @@ def write_run_directory(config, target_directory):
     """
     logger.debug(f"Writing run directory to {target_directory}")
     if config["namelist"]["fv_core_nml"].get("nudge", False):
-        config = update_config_for_nudging(config)
+        config = enable_nudging(config)
     write_assets_to_directory(config, target_directory)
     os.makedirs(os.path.join(target_directory, "RESTART"), exist_ok=True)
     current_date = get_current_date(config)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
             "fv3run=fv3config.fv3run.__main__:main",
             "write_run_directory=fv3config.cli:write_run_directory",
             "enable_restart=fv3config.cli:enable_restart",
-            "update_config_for_nudging=fv3config.cli:update_config_for_nudging",
+            "enable_nudging=fv3config.cli:enable_nudging",
         ]
     },
     install_requires=requirements,

--- a/tests/test_nudging.py
+++ b/tests/test_nudging.py
@@ -151,7 +151,7 @@ def test__is_nudging_asset(item, pattern, expected):
     assert nudging._is_nudging_asset(item, pattern) == expected
 
 
-def test_update_config_for_nudging(test_config):
+def test_enable_nudging(test_config):
     url = "/path/to/nudging/files"
     pattern = "%Y%m%d_%H.nc"
     old_nudging_file = "20151231_18.nc"
@@ -166,7 +166,7 @@ def test_update_config_for_nudging(test_config):
     }
     test_config["patch_files"] = [old_asset]
 
-    updated_config = fv3config.update_config_for_nudging(test_config)
+    updated_config = fv3config.enable_nudging(test_config)
 
     updated_file_names = updated_config["namelist"]["fv_nwp_nudge_nml"]["file_names"]
     assert f"INPUT/{old_nudging_file}" not in updated_file_names

--- a/tests/test_nudging.py
+++ b/tests/test_nudging.py
@@ -166,10 +166,10 @@ def test_update_config_for_nudging(test_config):
     }
     test_config["patch_files"] = [old_asset]
 
-    fv3config.update_config_for_nudging(test_config)
+    updated_config = fv3config.update_config_for_nudging(test_config)
 
-    updated_file_names = test_config["namelist"]["fv_nwp_nudge_nml"]["file_names"]
+    updated_file_names = updated_config["namelist"]["fv_nwp_nudge_nml"]["file_names"]
     assert f"INPUT/{old_nudging_file}" not in updated_file_names
     assert f"INPUT/{new_nudging_file}" in updated_file_names
-    assert old_asset not in test_config["patch_files"]
-    assert new_asset in test_config["patch_files"]
+    assert old_asset not in updated_config["patch_files"]
+    assert new_asset in updated_config["patch_files"]

--- a/tests/test_write_run_directory.py
+++ b/tests/test_write_run_directory.py
@@ -1,3 +1,4 @@
+import collections
 import unittest
 import tempfile
 import pytest
@@ -17,7 +18,7 @@ DEFAULT_CONFIG = c12_config()
 
 def update_recursive(base, update):
     for k, v in update.items():
-        if isinstance(v, dict):
+        if isinstance(v, collections.abc.Mapping):
             base[k] = update_recursive(base.get(k, {}), v)
         else:
             base[k] = v

--- a/tests/test_write_run_directory.py
+++ b/tests/test_write_run_directory.py
@@ -155,3 +155,35 @@ class CacheDirectoryTests(unittest.TestCase):
             fv3config.write_run_directory(config, rundir)
             assert "20160801_00.nc" in os.listdir(os.path.join(rundir, "INPUT"))
             assert "20160801_06.nc" in os.listdir(os.path.join(rundir, "INPUT"))
+
+    def test_write_run_directory_does_not_mutate_config(self):
+        config = copy.deepcopy(DEFAULT_CONFIG)
+        with tempfile.TemporaryDirectory() as rundir:
+            fv3config.write_run_directory(config, rundir)
+            assert config == DEFAULT_CONFIG
+
+    def test_write_run_directory_does_not_mutate_config_with_nudging_enabled(self):
+        config = copy.deepcopy(DEFAULT_CONFIG)
+        config["gfs_analysis_data"] = {
+            "url": "gs://vcm-fv3config/data/gfs_nudging_data/v1.0",
+            "filename_pattern": "%Y%m%d_%H.nc",
+        }
+        config["namelist"]["fv_core_nml"]["nudge"] = True
+        config_copy = copy.deepcopy(config)
+        with tempfile.TemporaryDirectory() as rundir:
+            fv3config.write_run_directory(config, rundir)
+            assert config == config_copy
+
+    def test_write_run_dir_does_not_mutate_config_with_initial_condition_list(self):
+        config = copy.deepcopy(DEFAULT_CONFIG)
+        config["initial_conditions"] = [
+            fv3config.get_asset_dict(
+                "gs://vcm-fv3config/data/initial_conditions/gfs_c12_example/v1.0",
+                "initial_conditions_file",
+                target_location="explicit",
+            )
+        ]
+        config_copy = copy.deepcopy(config)
+        with tempfile.TemporaryDirectory() as rundir:
+            fv3config.write_run_directory(config, rundir)
+            assert config == config_copy


### PR DESCRIPTION
Currently the `write_run_directory` function mutates the input if nudging is enabled. It also does so (in a subtle way) if the `config["initial_conditions"]` entry is a list. This PR adds tests for these cases and fixes them.

Resolves #130 