### PR TITLE
Remove gcsfs retry logic

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,11 @@ Bug fixes:
 - ensure ``fv3config.write_run_directory`` does not mutate input config
 - fix bug in which ``DiagTable.from_str`` failed on lines that contain only whitespace
 
+Minor changes
+~~~~~~~~~~~~~
+- The responsibility of retrying gcsfs operations is now delegated to gcsfs.
+  References to private gcsfs exceptions in fv3config have been removed.
+  
 
 v0.7.1 (2021-03-18)
 -------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,7 +17,6 @@ Bug fixes:
 Minor changes
 ~~~~~~~~~~~~~
 - The responsibility of retrying gcsfs operations is now delegated to gcsfs.
-  References to private gcsfs exceptions in fv3config have been removed.
   
 
 v0.7.1 (2021-03-18)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ requests>=2.22.0
 pyyaml>=5.0
 gcsfs>=0.7.0
 fsspec>=0.8.0
-backoff>=1.10
 dacite>=1.6.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,6 @@ wheel==0.33.6
 watchdog==0.9.0
 flake8==3.7.8
 tox==3.14.0
-backoff==1.10
 coverage==4.5.4
 Sphinx==1.8.5
 twine==1.14.0

--- a/tests/test_fv3run.py
+++ b/tests/test_fv3run.py
@@ -8,7 +8,6 @@ import tempfile
 import unittest
 import unittest.mock
 
-import gcsfs
 import pytest
 
 import fv3config
@@ -221,7 +220,7 @@ def test__output_stream_context_uncaptured(tmpdir):
 def maybe_get_file(*args, **kwargs):
     try:
         _original_get_file(*args, **kwargs)
-    except (OSError, gcsfs.utils.HttpError):
+    except OSError:
         pass
 
 


### PR DESCRIPTION
The retry logic should be unnecessary with the next version of gcsfs.

Closes #140